### PR TITLE
[FEATURE] 프로젝트 상세 페이지 조회 기능 개선

### DIFF
--- a/wise-office-server/build.gradle
+++ b/wise-office-server/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/CommentServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/CommentServiceApi.java
@@ -89,6 +89,10 @@ public class CommentServiceApi {
         ProjectEntity project = projectService.findById(projectId);
         CommentEntity comment = commentService.findCommentById(commentId);
 
+        if (isAdmin(loginUser)) {
+            return comment;
+        }
+
         AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
         if (!canModifyComment(loginUser, attendant, comment)) {
             throw new UnAuthorizationException(ErrorMessage.REJECT_MODIFYING_COMMENT);
@@ -98,10 +102,6 @@ public class CommentServiceApi {
     }
 
     private boolean canModifyComment(MemberEntity loginUser, AttendantEntity attendant, CommentEntity comment) {
-        if (isAdmin(loginUser)) {
-            return true;
-        }
-
         boolean isPM = attendant.getRole().equals(AttendantRoleType.PM); // PM 확인
         boolean isWriter = comment.getMember().getId().equals(loginUser.getId()); // 작성자인지 확인
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/CommentServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/CommentServiceApi.java
@@ -62,8 +62,8 @@ public class CommentServiceApi {
         if(isAdmin(loginUser)){
             modifyChecker = comment -> true;
         } else {
-            attendantService.validateParticipatingProject(loginUser, project);
-            modifyChecker = comment -> canModifyComment(loginUser, project, comment);
+            AttendantEntity attendant = attendantService.validateParticipatingProjectForViewing(loginUser, project);
+            modifyChecker = comment -> canModifyComment(loginUser, attendant, comment);
         }
 
         return commentsForLog.stream()
@@ -89,19 +89,19 @@ public class CommentServiceApi {
         ProjectEntity project = projectService.findById(projectId);
         CommentEntity comment = commentService.findCommentById(commentId);
 
-        if (!canModifyComment(loginUser, project, comment)) {
+        AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
+        if (!canModifyComment(loginUser, attendant, comment)) {
             throw new UnAuthorizationException(ErrorMessage.REJECT_MODIFYING_COMMENT);
         }
 
         return comment;
     }
 
-    private boolean canModifyComment(MemberEntity loginUser, ProjectEntity project, CommentEntity comment) {
+    private boolean canModifyComment(MemberEntity loginUser, AttendantEntity attendant, CommentEntity comment) {
         if (isAdmin(loginUser)) {
             return true;
         }
 
-        AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
         boolean isPM = attendant.getRole().equals(AttendantRoleType.PM); // PM 확인
         boolean isWriter = comment.getMember().getId().equals(loginUser.getId()); // 작성자인지 확인
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -61,7 +61,8 @@ public class LogServiceApi {
         }
 
         return logEntities.stream()
-                .map(log -> LogListResponse.from(log, modifyChecker.apply(log)))
+                .map(log -> LogListResponse.from(log, modifyChecker.apply(log),
+                        (int) log.getComments().stream().filter(c -> !c.isDeleted()).count()))
                 .toList();
     }
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -36,15 +36,14 @@ public class LogServiceApi {
     public LogDetailResponse createLog(String loginUserEmail, long projectId, LogCreateRequest request) {
         MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
         ProjectEntity project = projectService.findById(projectId);
-        AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
-        LogEntity newLog = logService.createLog(request, loginUser, project);
 
         //권한 확인
         if (!isAdmin(loginUser)) {
             attendantService.validateParticipatingProject(loginUser, project);
         }
 
-        return LogDetailResponse.from(newLog, hasModifyPermission(loginUser,attendant,newLog));
+        LogEntity newLog = logService.createLog(request, loginUser, project);
+        return LogDetailResponse.from(newLog, true);
     }
 
     public List<LogListResponse> getAllLogs(long projectId, String loginUserEmail) {

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -87,11 +87,7 @@ public class LogServiceApi {
         LogEntity log = getLogIfAuthorized(projectId, logId, loginUserEmail);
         LogEntity updatedLog = logService.updateLog(log, request);
 
-        MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
-        ProjectEntity project = projectService.findById(projectId);
-        AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
-
-        return LogDetailResponse.from(updatedLog, hasModifyPermission(loginUser, attendant, updatedLog));
+        return LogDetailResponse.from(updatedLog, true);
     }
 
     @Transactional

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -56,7 +56,7 @@ public class LogServiceApi {
         if (isAdmin(loginUser)) {
             modifyChecker = log -> true;
         } else {
-            AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
+            AttendantEntity attendant = attendantService.validateParticipatingProjectForViewing(loginUser, project);
             modifyChecker = log -> hasModifyPermission(loginUser, attendant, log);
         }
 
@@ -75,7 +75,7 @@ public class LogServiceApi {
         if (isAdmin(loginUser)) {
             modifyChecker = logs -> true;
         } else {
-            AttendantEntity attendant = attendantService.validateParticipatingProject(loginUser, project);
+            AttendantEntity attendant = attendantService.validateParticipatingProjectForViewing(loginUser, project);
             modifyChecker = logs -> hasModifyPermission(loginUser, attendant, log);
         }
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/dto/LogListResponse.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/dto/LogListResponse.java
@@ -15,13 +15,13 @@ public record LogListResponse(
         boolean canModify
 ) {
 
-    public static LogListResponse from(LogEntity logEntity, boolean canModify) {
+    public static LogListResponse from(LogEntity logEntity, boolean canModify, int count) {
         return new LogListResponse(
                 logEntity.getId(),
                 logEntity.getTitle(),
                 logEntity.getMember().getName(),
                 logEntity.getWrittenAt(),
-                logEntity.getComments().size(),
+                count,
                 // logEntity.getMember().getImageUrl(),
                 canModify // 파라미터로 받은 canModify 값을 그대로 사용
         );

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
@@ -7,9 +7,9 @@ import kr.co.wise.office.domain.Project.dto.ProjectUpdateRequest;
 import kr.co.wise.office.domain.Project.entity.ProjectEntity;
 import kr.co.wise.office.domain.Project.repository.ProjectRepository;
 import kr.co.wise.office.domain.member.entity.MemberEntity;
-import kr.co.wise.office.domain.member.service.MemberService;
 import kr.co.wise.office.exception.ErrorMessage;
 import kr.co.wise.office.exception.custom.NotFoundResourceException;
+import kr.co.wise.office.exception.custom.UnAuthorizationException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +22,6 @@ import java.util.List;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
-    private final MemberService memberService;
 
     /**
      * 모든 프로젝트와 매니저를 정보를 페이징없이 반환
@@ -42,9 +41,6 @@ public class ProjectService {
      */
     @Transactional
     public ProjectEntity makeProject(ProjectCreateRequest request, MemberEntity creator) {
-
-
-
         ProjectEntity projectEntity = ProjectEntity.builder()
                 .title(request.projectTitle())
                 .detail(request.content()) // content를 detail로 매핑
@@ -66,9 +62,8 @@ public class ProjectService {
 
         ProjectDetailResponse response = ProjectDetailResponse.loadProjectInfo(projectWithManager);
 
-        if (!currentUserEmail.equals("anonymousUser")) {
-            MemberEntity loginUser = memberService.findByEmail(currentUserEmail);
-            //response.setCanModify(projectWithManager.getMember().getId().equals(loginUser.getId()));
+        if (currentUserEmail.equals("anonymousUser")) {
+            throw new UnAuthorizationException(ErrorMessage.NOT_FOUND_MEMBER);
         }
 
         return response;

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectCreateRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectCreateRequest.java
@@ -2,6 +2,7 @@ package kr.co.wise.office.domain.Project.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kr.co.wise.office.api.validation.annotation.ValidDateRange;
 
 import java.time.LocalDate;
@@ -17,10 +18,11 @@ import java.util.List;
  * @param attendants 참여 인력 데이터베이스 PK 값
  */
 @ValidDateRange
-public record ProjectCreateRequest(@NotBlank(message = "프로젝트 제목은 빈칸일 수 없습니다.") String projectTitle,
-                               @NotNull(message = "시작일이 있어야 합니다.") LocalDate start,
-                               @NotNull(message = "종료일이 있어야 합니다.") LocalDate end,
-                               @NotBlank(message = "프로젝트 내용은 빈칸일 수 없습니다.") String content,
-                               @NotNull(message = "프로젝트 PM은 반드시 지정되어야 합니다.") Long projectManagerId,
-                               List<Long> attendants) {
+public record ProjectCreateRequest(
+        @NotBlank(message = "프로젝트 제목은 빈칸일 수 없습니다.") @Size(max = 100, message = "프로젝트 제목은 최대 100자까지만 작성가능합니다.") String projectTitle,
+        @NotNull(message = "시작일이 있어야 합니다.") LocalDate start,
+        @NotNull(message = "종료일이 있어야 합니다.") LocalDate end,
+        @NotBlank(message = "프로젝트 내용은 빈칸일 수 없습니다.") @Size(max = 500, message = "프로젝트 내용은 최대 500자까지만 작성가능합니다.") String content,
+        @NotNull(message = "프로젝트 PM은 반드시 지정되어야 합니다.") Long projectManagerId,
+        List<Long> attendants) {
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectUpdateRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectUpdateRequest.java
@@ -2,6 +2,7 @@ package kr.co.wise.office.domain.Project.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kr.co.wise.office.api.validation.annotation.ValidDateRange;
 
 import java.time.LocalDate;
@@ -17,12 +18,12 @@ import java.util.List;
  * @param attendants 참여 인력 데이터베이스 PK 값
  */
 @ValidDateRange
-public record ProjectUpdateRequest(@NotBlank(message = "프로젝트 제목은 빈칸일 수 없습니다.") String projectTitle,
-                                   @NotNull(message = "시작일이 있어야 합니다.") LocalDate start,
-                                   @NotNull(message = "종료일이 있어야 합니다.") LocalDate end,
-                                   @NotBlank(message = "프로젝트 내용은 빈칸일 수 없습니다.") String content,
-                                   @NotNull(message = "프로젝트 PM은 반드시 지정되어야 합니다.") Long projectManagerId,
-                                   List<Long> attendants) {
-
+public record ProjectUpdateRequest(
+        @NotBlank(message = "프로젝트 제목은 빈칸일 수 없습니다.") @Size(max = 100, message = "프로젝트 제목은 최대 100자까지만 작성가능합니다.") String projectTitle,
+        @NotNull(message = "시작일이 있어야 합니다.") LocalDate start,
+        @NotNull(message = "종료일이 있어야 합니다.") LocalDate end,
+        @NotBlank(message = "프로젝트 내용은 빈칸일 수 없습니다.") @Size(max = 500, message = "프로젝트 내용은 최대 500자까지만 작성가능합니다.") String content,
+        @NotNull(message = "프로젝트 PM은 반드시 지정되어야 합니다.") Long projectManagerId,
+        List<Long> attendants) {
 }
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/entity/ProjectEntity.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/entity/ProjectEntity.java
@@ -26,7 +26,7 @@ public class ProjectEntity {
     @Column(name = "title")
     private String title;
     
-    @Column(name ="detail")
+    @Column(name ="detail", length = 500)
     private String detail;
 
     @Column(name = "start_year")

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/attendant/service/AttendantService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/attendant/service/AttendantService.java
@@ -197,9 +197,28 @@ public class AttendantService {
         return response;
     }
 
+    public AttendantEntity validateParticipatingProjectForViewing(MemberEntity loginUser, ProjectEntity project) {
+        // PM/CREATOR 둘 다 있는 경우 방지
+        List<AttendantEntity> attendants = attendantRepository.findByMemberAndProject(loginUser, project);
+        // 프로젝트에 참여하지 않은 경우
+        if (attendants.isEmpty()) {
+            return AttendantEntity.builder()
+                    .role(AttendantRoleType.WORKER)
+                    .build();
+        }
+        if (attendants.size() == 1) {
+            return attendants.get(0);
+        }
+
+        // PM / CREATOR 둘 다 가지고 있는 경우 PM 권한이 있는 걸로 반환
+        AttendantEntity first = attendants.get(0);
+        return first.getRole() == AttendantRoleType.PM ? first : attendants.get(1);
+    }
+
     public AttendantEntity validateParticipatingProject(MemberEntity loginUser, ProjectEntity project) {
         // PM/CREATOR 둘 다 있는 경우 방지
         List<AttendantEntity> attendants = attendantRepository.findByMemberAndProject(loginUser, project);
+        // 프로젝트에 참여하지 않은 경우
         if (attendants.isEmpty()) {
             throw new NotFoundResourceException(ErrorMessage.NOT_FOUND_ATTENDANT);
         }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/comment/entity/CommentEntity.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/comment/entity/CommentEntity.java
@@ -45,5 +45,9 @@ public class CommentEntity {
         this.content = content;
     }
 
+    public void deleteComment(){
+        this.deleted = true;
+    }
+
 
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/comment/service/CommentService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/comment/service/CommentService.java
@@ -49,7 +49,8 @@ public class CommentService {
 
     @Transactional
     public void deleteComment(CommentEntity comment) {
-        commentRepository.delete(comment);
+        comment.deleteComment();
+        commentRepository.save(comment);
     }
 
     @Transactional

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/BaseTestEntity.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/BaseTestEntity.java
@@ -1,0 +1,99 @@
+package kr.co.wise.office.application;
+
+import jakarta.persistence.EntityManager;
+import kr.co.wise.office.domain.Project.dto.ProjectCreateRequest;
+import kr.co.wise.office.domain.Project.dto.ProjectCreateResponse;
+import kr.co.wise.office.domain.Project.repository.ProjectRepository;
+import kr.co.wise.office.domain.attendant.repository.AttendantRepository;
+import kr.co.wise.office.domain.member.entity.MemberEntity;
+import kr.co.wise.office.domain.member.entity.MemberRoleType;
+import kr.co.wise.office.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+public abstract class BaseTestEntity {
+
+    @Autowired
+    protected EntityManager em;
+    @Autowired
+    protected ProjectServiceApiV2 projectServiceApiV2;
+    @Autowired
+    protected MemberRepository memberRepository;
+    @Autowired
+    protected ProjectRepository projectRepository;
+    @Autowired
+    protected AttendantRepository attendantRepository;
+
+    protected MemberCreationInfo pmInfo = new MemberCreationInfo("pm", "pm@test.co.kr");
+    protected MemberCreationInfo adminInfo = new MemberCreationInfo("admin", "admin@test.co.kr");
+    protected MemberCreationInfo creatorInfo = new MemberCreationInfo("creator", "creator@test.co.kr");
+    protected MemberCreationInfo workerInfo1 = new MemberCreationInfo("worker1", "worker1@test.co.kr");
+    protected MemberCreationInfo workerInfo2 = new MemberCreationInfo("worker2", "worker2@test.co.kr");
+    protected static final LocalDate BASE_DATE = LocalDate.of(2025, 1, 1);
+
+    protected Long projectId;
+    protected MemberEntity pm;
+    protected MemberEntity worker1;
+    protected MemberEntity worker2;
+    protected MemberEntity creator;
+    protected MemberEntity admin;
+
+    @BeforeEach
+    void setUp() {
+        this.pm = createMember(pmInfo.email, pmInfo.name, MemberRoleType.WORKER);
+        this.worker1 = createMember(workerInfo1.email, workerInfo1.name, MemberRoleType.WORKER);
+        this.worker2 = createMember(workerInfo2.email, workerInfo2.name, MemberRoleType.WORKER);
+        this.creator = createMember(creatorInfo.email, creatorInfo.name, MemberRoleType.WORKER);
+        this.admin = createMember(adminInfo.email, adminInfo.name, MemberRoleType.MASTER);
+
+        ProjectCreateRequest request = new ProjectCreateRequest("title", BASE_DATE, BASE_DATE.plusDays(10),
+                "content", pm.getId(), List.of(worker1.getId(), worker2.getId(), creator.getId()));
+        ProjectCreateResponse response = projectServiceApiV2.createProjectV2(request, creator.getEmail());
+        this.projectId = response.getProjectId();
+    }
+
+    protected MemberEntity createMember(String email, String name, MemberRoleType role) {
+        return memberRepository.save(
+                MemberEntity.builder()
+                        .email(email)
+                        .name(name)
+                        .roleType(role)
+                        .build());
+    }
+
+    protected MemberEntity createMember(String email, String name) {
+        return createMember(email, name, MemberRoleType.WORKER);
+    }
+
+    protected ProjectCreateRequest createProjectRequest(
+            String title,
+            String content,
+            Long pmId,
+            List<Long> workerIds
+    ) {
+        return new ProjectCreateRequest(
+                title,
+                BASE_DATE,
+                BASE_DATE.plusDays(10),
+                content,
+                pmId,
+                workerIds);
+    }
+
+    public static class MemberCreationInfo {
+        public String name;
+        public String email;
+
+        public MemberCreationInfo(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+    }
+}

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/CommentServiceApiTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/CommentServiceApiTest.java
@@ -1,0 +1,189 @@
+package kr.co.wise.office.application;
+
+
+import kr.co.wise.office.domain.Log.dto.LogCreateRequest;
+import kr.co.wise.office.domain.Log.dto.LogDetailResponse;
+import kr.co.wise.office.domain.comment.dto.CommentCreateRequest;
+import kr.co.wise.office.domain.comment.dto.CommentResponse;
+import kr.co.wise.office.domain.comment.dto.CommentUpdateRequest;
+import kr.co.wise.office.domain.comment.dto.CommentUpdateResponse;
+import kr.co.wise.office.domain.comment.entity.CommentEntity;
+import kr.co.wise.office.domain.comment.repository.CommentRepository;
+import kr.co.wise.office.domain.member.entity.MemberEntity;
+import kr.co.wise.office.domain.member.entity.MemberRoleType;
+import kr.co.wise.office.exception.ErrorMessage;
+import kr.co.wise.office.exception.custom.NotFoundResourceException;
+import kr.co.wise.office.exception.custom.UnAuthorizationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CommentServiceApiTest extends BaseTestEntity {
+
+    @Autowired
+    private CommentServiceApi commentServiceApi;
+    @Autowired
+    private LogServiceApi logServiceApi;
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private long logId;
+
+    private final String defaultCommentContent = "comment content";
+    private CommentCreateRequest defaultCommentRequest;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        LogCreateRequest logRequest = new LogCreateRequest("log", "content");
+        LogDetailResponse logResponse = logServiceApi.createLog(workerInfo1.email, this.projectId, logRequest);
+        this.logId = logResponse.logId();
+        this.defaultCommentRequest = new CommentCreateRequest(defaultCommentContent);
+    }
+
+    private CommentResponse createComment(String email) {
+        return commentServiceApi.createComment(projectId, logId, email, defaultCommentRequest);
+    }
+
+    @Test
+    @DisplayName("생성된 프로젝트의 댓글은 해당 프로젝트 참여자 및 ADMIN 유저만 가능하다.")
+    void createComment_withProjectMembersAndAdmin_success() {
+        // given
+
+        // when
+        commentServiceApi.createComment(projectId, logId, pmInfo.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, logId, workerInfo1.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, logId, workerInfo2.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, logId, adminInfo.email, defaultCommentRequest);
+        em.flush();
+        em.clear();
+
+        //then
+        List<CommentResponse> adminResponses = commentServiceApi.getCommentsForLog(projectId, logId, adminInfo.email);
+        assertThat(adminResponses.size()).isEqualTo(4);
+        assertThat(adminResponses).extracting(CommentResponse::canModify)
+                .as("ADMIN은 모든 댓글을 수정할 수 있음").containsExactly(true, true, true, true);
+        assertThat(adminResponses).extracting("content").containsExactly(defaultCommentContent, defaultCommentContent, defaultCommentContent, defaultCommentContent);
+        List<CommentResponse> pmResponses = commentServiceApi.getCommentsForLog(projectId, logId, pmInfo.email);
+        assertThat(pmResponses).extracting(CommentResponse::canModify)
+                .as("PM은 모든 댓글을 수정할 수 있음").containsExactly(true, true, true, true);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 참여중이지 않은 사람이 댓글 작성시 예외가 발생해야 한다.")
+    void createComment_notInProject_shouldThrow() {
+        //given
+        MemberCreationInfo anonymousInfo = new MemberCreationInfo("anonymous", "anoynmous@test.co.kr");
+        MemberEntity anonymous = createMember(anonymousInfo.email, anonymousInfo.name, MemberRoleType.WORKER);
+
+        //when + then
+        assertThatThrownBy(() -> commentServiceApi.createComment(projectId, logId, anonymous.getEmail(), defaultCommentRequest))
+                .isInstanceOf(NotFoundResourceException.class)
+                .extracting("errorMessage")
+                .isEqualTo(ErrorMessage.NOT_FOUND_ATTENDANT);
+    }
+
+    @Test
+    @DisplayName("Worker는 자신이 작성한 댓글만 삭제할 수 있다")
+    void removeComment_withWorkerRole_canModifyOwnLog(){
+        //given
+        String worker1Email = workerInfo1.email;
+        String otherWorkerEmail = workerInfo2.email;
+        CommentResponse comment1 = createComment(worker1Email);
+        CommentResponse comment2 = createComment(otherWorkerEmail);
+
+        //when
+        commentServiceApi.removeComment(projectId, comment1.id(), worker1Email);
+        List<CommentResponse> commentsForLog = commentServiceApi.getCommentsForLog(projectId, logId, worker1Email);
+
+        //then
+        assertThat(commentsForLog.size()).isEqualTo(1);
+        assertThatThrownBy(() -> commentServiceApi.removeComment(projectId, comment2.id(), worker1Email))
+                .as("다른 사람이 작성한 댓글 삭제시 에러 발생")
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_COMMENT);
+    }
+
+    @Test
+    @DisplayName("Worker는 자신이 작성한 댓글만 수정할 수 있다")
+    void updateComment_withWorkerRole_canModifyOwnLog(){
+        //given
+        String worker1Email = workerInfo1.email;
+        String otherWorkerEmail = workerInfo2.email;
+        CommentResponse comment1 = createComment(worker1Email);
+        CommentResponse comment2 = createComment(otherWorkerEmail);
+
+        CommentUpdateRequest request = new CommentUpdateRequest("update comment");
+        //when
+        CommentUpdateResponse updateResponse = commentServiceApi.updateComment(projectId, comment1.id(), worker1Email, request);
+
+        CommentEntity updateComment = commentRepository.findById(comment1.id()).get();
+
+        //then
+        assertThat(updateComment.getContent()).as("업데이트된 내용은 요청 내용과 같아야 함").isEqualTo(request.content());
+        assertThatThrownBy(() -> commentServiceApi.removeComment(projectId, comment2.id(), worker1Email))
+                .as("다른 사람이 작성한 댓글 수정시 에러 발생")
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_COMMENT);
+    }
+
+    @DisplayName("프로젝트 관리자(PM) 및 ADMIN 유저는 프로젝트 내의 모든 댓글을 수정할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"pm@test.co.kr", "admin@test.co.kr"})
+    void updateComment_withManagerRole_canModifyAnyLog(String managerEmail) {
+        //given
+        String worker1Email = workerInfo1.email;
+        String otherWorkerEmail = workerInfo2.email;
+        CommentResponse comment1 = createComment(worker1Email);
+        CommentResponse comment2 = createComment(otherWorkerEmail);
+        String updateContent1 = "update comment1";
+        String updateContent2 = "update comment2";
+        CommentUpdateRequest request1 = new CommentUpdateRequest(updateContent1);
+        CommentUpdateRequest request2 = new CommentUpdateRequest(updateContent2);
+
+        //when
+        commentServiceApi.updateComment(projectId, comment1.id(), managerEmail, request1);
+        commentServiceApi.updateComment(projectId, comment2.id(), managerEmail, request2);
+
+        //then
+        CommentEntity commentEntity1 = commentRepository.findById(comment1.id()).get();
+        CommentEntity commentEntity2 = commentRepository.findById(comment2.id()).get();
+        assertThat(commentEntity1.getContent()).isEqualTo(request1.content());
+        assertThat(commentEntity2.getContent()).isEqualTo(request2.content());
+    }
+
+    @DisplayName("프로젝트 관리자(PM) 및 ADMIN 유저는 프로젝트 내의 모든 댓글을 삭제할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"pm@test.co.kr", "admin@test.co.kr"})
+    void deleteComment_withManagerRole_canModifyAnyLog(String managerEmail) {
+        //given
+        String worker1Email = workerInfo1.email;
+        String otherWorkerEmail = workerInfo2.email;
+        CommentResponse comment1 = createComment(worker1Email);
+        CommentResponse comment2 = createComment(otherWorkerEmail);
+        CommentResponse notRemoveComment = createComment(worker1Email);
+
+        //when
+        commentServiceApi.removeComment(projectId, comment1.id(), managerEmail);
+        commentServiceApi.removeComment(projectId, comment2.id(), managerEmail);
+        em.flush();
+        em.clear();
+
+        //then
+        List<CommentResponse> commentsForLog = commentServiceApi.getCommentsForLog(projectId, logId, worker1Email);
+        assertThat(commentsForLog.size()).as("3개중에 2개가 식제됐으므로 하나가 남아야 함").isEqualTo(1);
+        assertThat(commentsForLog).extracting("content")
+                .as("남은 하나는 notRemoveComment의 내용과 같아야 함")
+                .isEqualTo(List.of(notRemoveComment.content()));
+    }
+}

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/LogServiceApiTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/LogServiceApiTest.java
@@ -1,0 +1,207 @@
+package kr.co.wise.office.application;
+
+import kr.co.wise.office.domain.Log.dto.LogCreateRequest;
+import kr.co.wise.office.domain.Log.dto.LogDetailResponse;
+import kr.co.wise.office.domain.Log.dto.LogListResponse;
+import kr.co.wise.office.domain.Log.dto.LogUpdateRequest;
+import kr.co.wise.office.domain.member.entity.MemberEntity;
+import kr.co.wise.office.domain.member.entity.MemberRoleType;
+import kr.co.wise.office.exception.ErrorMessage;
+import kr.co.wise.office.exception.custom.NotFoundResourceException;
+import kr.co.wise.office.exception.custom.UnAuthorizationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LogServiceApiTest extends BaseTestEntity {
+
+    @Autowired
+    private LogServiceApi logServiceApi;
+
+    private final String defaultLogTitle = "log title";
+    private final String defaultLogContent = "log content";
+    private final LogCreateRequest defaultLogRequest = new LogCreateRequest(defaultLogTitle, defaultLogContent);
+
+    private LogDetailResponse createLog(String email) {
+        return logServiceApi.createLog(email, projectId, defaultLogRequest);
+    }
+
+    @Test
+    @DisplayName("생성된 프로젝트의 로그는 해당 프로젝트 참여자 및 ADMIN 유저만 가능하다.")
+    void createLog_withProjectMembersAndAdmin_success() {
+        // given
+
+        // when
+        logServiceApi.createLog(pmInfo.email, projectId, defaultLogRequest);
+        logServiceApi.createLog(workerInfo1.email, projectId, defaultLogRequest);
+        logServiceApi.createLog(workerInfo2.email, projectId, defaultLogRequest);
+        logServiceApi.createLog(adminInfo.email, projectId, defaultLogRequest);
+
+        //then
+        List<LogListResponse> adminResponses = logServiceApi.getAllLogs(projectId, adminInfo.email);
+        assertThat(adminResponses.size()).isEqualTo(4);
+        assertThat(adminResponses).extracting(LogListResponse::canModify).containsExactly(true, true, true, true).as("ADMIN은 모든 로그를 수정할 수 있음");
+
+        List<LogListResponse> pmResponses = logServiceApi.getAllLogs(projectId, pmInfo.email);
+        assertThat(pmResponses).extracting(LogListResponse::canModify).containsExactly(true, true, true, true).as("PM은 모든 로그를 수정할 수 있음");
+    }
+
+    @Test
+    @DisplayName("프로젝트에 참여중이지 않은 사람이 로그 작성시 예외가 발생해야 한다.")
+    void createLog_notInProject_shouldThrow() {
+        //given
+        MemberCreationInfo anonymousInfo = new MemberCreationInfo("anonymous", "anoynmous@test.co.kr");
+        MemberEntity anonymous = createMember(anonymousInfo.email, anonymousInfo.name, MemberRoleType.WORKER);
+        //when + then
+        assertThatThrownBy(() -> logServiceApi.createLog(anonymous.getEmail(), projectId, defaultLogRequest)).isInstanceOf(NotFoundResourceException.class);
+    }
+
+    @Test
+    @DisplayName("ADMIN은 자신이 작성하지 않은 로그도 수정할 수 있다")
+    void updateLog_withAdminRole_canModifyAnyLog(){
+        //given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        final String updateTitle = "update title";
+        final String updateContent = "update content";
+        LogUpdateRequest updateRequest = new LogUpdateRequest(updateTitle, updateContent);
+
+        //when
+        LogDetailResponse updateResponse1 = logServiceApi.updateLog(projectId, logResponse1.logId(), adminInfo.email, updateRequest);
+        LogDetailResponse logDetail2 = logServiceApi.getDetailLog(logResponse2.logId(), projectId, adminInfo.email);
+
+        //then
+        assertThat(updateResponse1.title()).isEqualTo(updateRequest.title()).as("수정 후 요청 제목과 같아야 함");
+        assertThat(updateResponse1.content()).isEqualTo(updateRequest.content()).as("수정 후 요청 본문과 같아야 함");
+        assertThat(updateResponse1.canModify()).isTrue().as("수정 후에도 삭제가 가능해야 함");
+        assertThat(logDetail2.title()).isEqualTo("log title").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.content()).isEqualTo("log content").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.canModify()).isTrue().as("수정 후에도 삭제가 가능해야 함");
+    }
+
+    @Test
+    @DisplayName("ADMIN은 어떤 로그든 삭제할 수 있다.")
+    void deleteLog_withAdminRole_canDeleteAnyLog(){
+        //given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        logServiceApi.removeLog(projectId, logResponse1.logId(), adminInfo.email);
+        logServiceApi.removeLog(projectId, logResponse2.logId(), adminInfo.email);
+
+        //when
+        List<LogListResponse> responses = logServiceApi.getAllLogs(projectId, adminInfo.email);
+
+        //then
+        assertThat(responses.size()).isEqualTo(0).as("모든 로그를 삭제했으므로 0개가 조회되어야 함");
+    }
+
+    @Test
+    @DisplayName("PM은 프로젝트내 자신이 작성하지 않은 로그도 수정할 수 있다")
+    void updateLog_withPmRole_canModifyAnyLog(){
+        //given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        final String updateTitle = "update title";
+        final String updateContent = "update content";
+        LogUpdateRequest updateRequest = new LogUpdateRequest(updateTitle, updateContent);
+
+        //when
+        LogDetailResponse updateResponse1 = logServiceApi.updateLog(projectId, logResponse1.logId(), pmInfo.email, updateRequest);
+        LogDetailResponse logDetail2 = logServiceApi.getDetailLog(logResponse2.logId(), projectId, pmInfo.email);
+
+        //then
+        assertThat(updateResponse1.title()).isEqualTo(updateRequest.title()).as("수정 후 요청 제목과 같아야 함");
+        assertThat(updateResponse1.content()).isEqualTo(updateRequest.content()).as("수정 후 요청 본문과 같아야 함");
+        assertThat(updateResponse1.canModify()).isTrue().as("수정 후에도 삭제가 가능해야 함");
+        assertThat(logDetail2.title()).isEqualTo("log title").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.content()).isEqualTo("log content").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.canModify()).isTrue().as("수정 후에도 삭제가 가능해야 함");
+    }
+
+    @Test
+    @DisplayName("PM은 프로젝트 내의 어떤 로그든 삭제할 수 있다")
+    void deleteLog_withPmRole_canDeleteAnyLog(){
+        //given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        logServiceApi.removeLog(projectId, logResponse1.logId(), pmInfo.email);
+        logServiceApi.removeLog(projectId, logResponse2.logId(), pmInfo.email);
+
+        //when
+        List<LogListResponse> responses = logServiceApi.getAllLogs(projectId, pmInfo.email);
+
+        //then
+        assertThat(responses.size()).isEqualTo(0).as("모든 로그를 삭제했으므로 0개가 조회되어야 함");
+    }
+
+    @DisplayName("worker는 자신이 작성한 로그만 수정할 수 있다")
+    @Test
+    void updateLog_withWorkerRole_canModifyOwnLog(){
+        // given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        final String updateTitle = "update title";
+        final String updateContent = "update content";
+        LogUpdateRequest updateRequest = new LogUpdateRequest(updateTitle, updateContent);
+
+        //when
+        LogDetailResponse updateResponse1 = logServiceApi.updateLog(projectId, logResponse1.logId(), workerInfo1.email, updateRequest);
+        LogDetailResponse logDetail2 = logServiceApi.getDetailLog(logResponse2.logId(), projectId, workerInfo1.email);
+
+        //then
+        assertThat(updateResponse1.title()).isEqualTo(updateRequest.title()).as("수정 후 요청 제목과 같아야 함");
+        assertThat(updateResponse1.content()).isEqualTo(updateRequest.content()).as("수정 후 요청 본문과 같아야 함");
+        assertThat(updateResponse1.canModify()).isTrue().as("worker는 자신이 작성한 로그는 또 수정할 수 있음");
+        assertThat(logDetail2.title()).isEqualTo("log title").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.content()).isEqualTo("log content").as("수정하지 않은 로그 제목에는 변화가 없어야 함");
+        assertThat(logDetail2.canModify()).isFalse().as("worker는 자신이 작성한 로그만 수정할 수 있음");
+    }
+
+    @DisplayName("worker는 다른 사람이 작성한 로그를 수정할 수 없다")
+    @Test
+    void updateLog_withWorkerRole_cannotModifyOtherLog(){
+        // given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        final String updateTitle = "update title";
+        final String updateContent = "update content";
+        LogUpdateRequest updateRequest = new LogUpdateRequest(updateTitle, updateContent);
+
+        //when
+        LogDetailResponse updateResponse1 = logServiceApi.updateLog(projectId, logResponse1.logId(), workerInfo1.email, updateRequest);
+        LogDetailResponse logDetail2 = logServiceApi.getDetailLog(logResponse2.logId(), projectId, workerInfo1.email);
+
+        //then
+        assertThatThrownBy(() -> logServiceApi.updateLog(projectId, logResponse2.logId(), workerInfo1.email, updateRequest))
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_LOG);
+        assertThat(logDetail2.canModify()).isFalse().as("자신이 작성한 로그는 수정할 수 없음.");
+    }
+
+    @DisplayName("worker는 다른 사람이 작성한 로그를 삭제 수 없다")
+    @Test
+    void deleteLog_withWorkerRole_cannotDeleteOtherLog(){
+        // given
+        LogDetailResponse logResponse1 = createLog(workerInfo1.email);
+        LogDetailResponse logResponse2 = createLog(workerInfo2.email);
+        final String updateTitle = "update title";
+        final String updateContent = "update content";
+        LogUpdateRequest updateRequest = new LogUpdateRequest(updateTitle, updateContent);
+
+        //when + then
+        assertThatThrownBy(() -> logServiceApi.removeLog(projectId, logResponse2.logId(), workerInfo1.email))
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_LOG);
+    }
+
+    
+
+
+}

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/LogServiceApiTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/LogServiceApiTest.java
@@ -4,6 +4,8 @@ import kr.co.wise.office.domain.Log.dto.LogCreateRequest;
 import kr.co.wise.office.domain.Log.dto.LogDetailResponse;
 import kr.co.wise.office.domain.Log.dto.LogListResponse;
 import kr.co.wise.office.domain.Log.dto.LogUpdateRequest;
+import kr.co.wise.office.domain.comment.dto.CommentCreateRequest;
+import kr.co.wise.office.domain.comment.dto.CommentResponse;
 import kr.co.wise.office.domain.member.entity.MemberEntity;
 import kr.co.wise.office.domain.member.entity.MemberRoleType;
 import kr.co.wise.office.exception.ErrorMessage;
@@ -22,10 +24,15 @@ public class LogServiceApiTest extends BaseTestEntity {
 
     @Autowired
     private LogServiceApi logServiceApi;
+    @Autowired
+    private CommentServiceApi commentServiceApi;
 
     private final String defaultLogTitle = "log title";
     private final String defaultLogContent = "log content";
     private final LogCreateRequest defaultLogRequest = new LogCreateRequest(defaultLogTitle, defaultLogContent);
+
+    private final String defaultComment = "comment";
+    private final CommentCreateRequest defaultCommentRequest = new CommentCreateRequest(defaultComment);
 
     private LogDetailResponse createLog(String email) {
         return logServiceApi.createLog(email, projectId, defaultLogRequest);
@@ -201,7 +208,34 @@ public class LogServiceApiTest extends BaseTestEntity {
                 .isEqualTo(ErrorMessage.REJECT_MODIFYING_LOG);
     }
 
-    
+    @DisplayName("로그 리스트 조회시 삭제된 댓글은 계산에 포함되면 안된다.")
+    @Test
+    void notContain_deleteComment_calculatingSum() {
+        //given
+        LogDetailResponse log = createLog(workerInfo1.email);
+        LogDetailResponse log2 = createLog(workerInfo2.email);
+        commentServiceApi.createComment(projectId, log.logId(), adminInfo.email, defaultCommentRequest);
+        CommentResponse removeComment1 = commentServiceApi.createComment(projectId, log.logId(), workerInfo1.email, defaultCommentRequest);
+        CommentResponse removeComment2 = commentServiceApi.createComment(projectId, log.logId(), workerInfo2.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, log.logId(), pmInfo.email, defaultCommentRequest);
+        CommentResponse removeComment3 = commentServiceApi.createComment(projectId, log.logId(), workerInfo2.email, defaultCommentRequest);
+        commentServiceApi.removeComment(projectId, removeComment1.id(), pmInfo.email);
+        commentServiceApi.removeComment(projectId, removeComment2.id(), adminInfo.email);
+        commentServiceApi.removeComment(projectId, removeComment3.id(), workerInfo2.email);
 
+        commentServiceApi.createComment(projectId, log2.logId(), adminInfo.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, log2.logId(), adminInfo.email, defaultCommentRequest);
+        commentServiceApi.createComment(projectId, log2.logId(), adminInfo.email, defaultCommentRequest);
 
+        em.flush();
+        em.clear();;
+
+        //when
+        List<LogListResponse> responses = logServiceApi.getAllLogs(projectId, workerInfo1.email);
+
+        //then
+        assertThat(responses.size()).as("로그는 두개가 조회되어야 함").isEqualTo(2);
+        assertThat(responses).as("첫 번째 로그에는 2개, 두 번째 로그에는 댓글 개수 3개가 조회되어야 함")
+                .extracting("commentCnt").containsExactlyInAnyOrder(2, 3);
+    }
 }

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/ProjectServiceApiV2Test.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/ProjectServiceApiV2Test.java
@@ -1,0 +1,297 @@
+package kr.co.wise.office.application;
+
+import kr.co.wise.office.domain.Project.dto.ProjectCreateRequest;
+import kr.co.wise.office.domain.Project.dto.ProjectCreateResponse;
+import kr.co.wise.office.domain.Project.dto.ProjectDetailResponse;
+import kr.co.wise.office.domain.Project.dto.ProjectUpdateRequest;
+import kr.co.wise.office.domain.Project.entity.ProjectEntity;
+import kr.co.wise.office.domain.attendant.entity.AttendantEntity;
+import kr.co.wise.office.domain.attendant.entity.AttendantRoleType;
+import kr.co.wise.office.domain.member.entity.MemberEntity;
+import kr.co.wise.office.domain.member.entity.MemberRoleType;
+import kr.co.wise.office.exception.ErrorMessage;
+import kr.co.wise.office.exception.custom.NotFoundResourceException;
+import kr.co.wise.office.exception.custom.UnAuthorizationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class ProjectServiceApiV2Test extends BaseTestEntity {
+
+    @Autowired
+    private ProjectServiceApiV2 projectServiceApiV2;
+
+    private static final LocalDate BASE_DATE = LocalDate.of(2025, 1, 1);
+
+    @Test
+    @DisplayName("프로젝트 생성 성공 시, PM/Creator/Workers가 올바르게 저장된다")
+    void createProject_success() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+        MemberEntity worker1 = createMember("worker1@test.com", "Worker1");
+        MemberEntity worker2 = createMember("worker2@test.com", "Worker2");
+
+        ProjectCreateRequest request = createProjectRequest(
+                "Project Title Test",
+                "Project Content Test",
+                pm.getId(),
+                List.of(worker1.getId(), worker2.getId())
+        );
+
+        // when
+        ProjectCreateResponse response = projectServiceApiV2.createProjectV2(request, creator.getEmail());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getProjectTitle()).isEqualTo("Project Title Test");
+        assertThat(response.getManagerName()).isEqualTo(pm.getName());
+
+        ProjectEntity createdProject = projectRepository.findAll().get(1);
+        assertThat(createdProject.getTitle()).isEqualTo("Project Title Test");
+
+        List<AttendantEntity> attendants = attendantRepository.findAttendantsByProjectIdWithMember(createdProject);
+        assertThat(attendants).hasSize(4);
+
+        assertThat(attendants).as("PM이 등록되어야 한다")
+                .anyMatch(a -> a.getMember().getId().equals(pm.getId()) && a.getRole() == AttendantRoleType.PM);
+
+        assertThat(attendants).as("Creator가 등록되어야 한다")
+                .anyMatch(a -> a.getMember().getId().equals(creator.getId()) && a.getRole() == AttendantRoleType.CREATOR);
+
+        long workerCount = attendants.stream().filter(att -> att.getRole() == AttendantRoleType.WORKER).count();
+        assertThat(workerCount).as("Worker 2명이 등록되어야 한다").isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("PM이 프로젝트 수정 성공 시, PM 교체 및 참여자 정보가 올바르게 반영된다")
+    void updateProject_success() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity initialPm = createMember("initialPm@test.com", "InitialPM");
+        MemberEntity newWorker = createMember("newWorker1@test.com", "newWorker1");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Initial Title", "Initial Content", initialPm.getId(), List.of()),
+                creator.getEmail());
+        long projectId = createResponse.getProjectId();
+
+        MemberEntity newPm = createMember("newPm@test.com", "NewPM");
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest("Updated Title",
+                BASE_DATE.plusDays(1),
+                BASE_DATE.plusDays(20),
+                "Updated Content",
+                newPm.getId(),
+                List.of(creator.getId(), newWorker.getId()));
+
+        // when
+        projectServiceApiV2.updateProject(projectId, initialPm.getEmail(), updateRequest);
+
+        // then
+        ProjectEntity updatedProject = projectRepository.findById(projectId).orElseThrow();
+        assertThat(updatedProject.getTitle()).isEqualTo("Updated Title");
+        assertThat(updatedProject.getDetail()).isEqualTo("Updated Content");
+
+        List<AttendantEntity> attendants = attendantRepository.findAttendantsByProjectIdWithMember(updatedProject);
+        assertThat(attendants).as("새로운 PM이 정상적으로 반영되어야 한다")
+                .anyMatch(a -> a.getMember().getId().equals(newPm.getId()) && a.getRole() == AttendantRoleType.PM && a.getLeftAt() == null);
+        assertThat(attendants).as("이전 PM은 더 이상 활동 중이지 않아야 한다")
+                .noneMatch(a -> a.getMember().getId().equals(initialPm.getId()) && a.getRole() == AttendantRoleType.PM && a.getLeftAt() == null);
+
+        long activeCount = attendants.stream().filter(a -> a.getLeftAt() == null).count();
+        assertThat(activeCount).as("Creator와 NewPM, newWorker 세 명만 참여 중이어야 한다").isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("PM이 프로젝트 종료 성공 시, 모든 참여자가 leftAt이 설정된다")
+    void closeProject_success() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("To Be Closed", "Content", pm.getId(), List.of()),
+                creator.getEmail()
+        );
+        long projectId = createResponse.getProjectId();
+
+        // when
+        projectServiceApiV2.closeProject(projectId, pm.getEmail());
+
+        // then
+        ProjectEntity closedProject = projectRepository.findById(projectId).orElseThrow();
+        assertThat(closedProject.isClosed()).isTrue();
+
+        List<AttendantEntity> attendants = attendantRepository.findAttendantsByProjectIdWithMember(closedProject);
+        assertThat(attendants).as("프로젝트 종료 시 모든 참여자가 떠나야 한다").allMatch(a -> a.getLeftAt() != null);
+    }
+
+    @Test
+    @DisplayName("프로젝트에 참여하지 않은 사람이 프로젝트 수정 시도 시 예외 발생")
+    void updateProject_withUnauthorizedUser_shouldThrowException() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of()),
+                creator.getEmail());
+
+        long projectId = createResponse.getProjectId();
+        MemberEntity outsider = createMember("outsider@test.com", "Outsider");
+
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Updated Title",
+                BASE_DATE.plusDays(1),
+                BASE_DATE.plusDays(20),
+                "Updated Content",
+                pm.getId(),
+                List.of(creator.getId()));
+
+        // when & then
+        assertThatThrownBy(() -> projectServiceApiV2.updateProject(projectId, outsider.getEmail(), updateRequest))
+                .isInstanceOf(NotFoundResourceException.class)
+                .extracting("errorMessage").extracting("message")
+                .isEqualTo(ErrorMessage.NOT_FOUND_ATTENDANT.getMessage());
+    }
+
+    @Test
+    @DisplayName("프로젝트에 참여하지 않은 사람이 프로젝트 삭제 시도 시 예외 발생")
+    void closeProject_withUnauthorizedUser_shouldThrowException() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of()),
+                creator.getEmail()
+        );
+
+        long projectId = createResponse.getProjectId();
+        MemberEntity outsider = createMember("outsider@test.com", "Outsider");
+
+        assertThatThrownBy(() -> projectServiceApiV2.closeProject(projectId, outsider.getEmail()))
+                .isInstanceOf(NotFoundResourceException.class)
+                .extracting("errorMessage").extracting("message")
+                .isEqualTo(ErrorMessage.NOT_FOUND_ATTENDANT.getMessage());
+    }
+
+    @Test
+    @DisplayName("WORKER가 프로젝트 종료시 예외 발생")
+    void closeProject_withWorkerUser_shouldThrowException(){
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+        MemberEntity worker = createMember("worker@test.com", "worker");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of(worker.getId())),
+                creator.getEmail()
+        );
+
+        long projectId = createResponse.getProjectId();
+
+
+        assertThatThrownBy(() -> projectServiceApiV2.closeProject(projectId, worker.getEmail()))
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage").extracting("message")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_PROJECT.getMessage());
+    }
+
+    @Test
+    @DisplayName("WORKER가 프로젝트 수정시 예외 발생")
+    void updateProject_withWorkerUser_shouldThrowException(){
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+        MemberEntity worker = createMember("worker@test.com", "worker");
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of(worker.getId())),
+                creator.getEmail()
+        );
+        long projectId = createResponse.getProjectId();
+
+        //when
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Updated Title",
+                BASE_DATE.plusDays(1),
+                BASE_DATE.plusDays(20),
+                "Updated Content",
+                worker.getId(),
+                List.of(creator.getId()));
+
+        //then
+        assertThatThrownBy(() -> projectServiceApiV2.updateProject(projectId, worker.getEmail(), updateRequest))
+                .isInstanceOf(UnAuthorizationException.class)
+                .extracting("errorMessage").extracting("message")
+                .isEqualTo(ErrorMessage.REJECT_MODIFYING_PROJECT.getMessage());;
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한을 가진 유저는 참여하지 않은 프로젝트 업데이트가 가능함.")
+    void updateProject_withAdminUser_shouldUpdatePossible() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+        MemberEntity worker = createMember("worker@test.com", "worker");
+        MemberEntity admin = memberRepository.save(MemberEntity.builder()
+                .name("admin").email("admin@test.com").roleType(MemberRoleType.MASTER).build());
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of()),
+                creator.getEmail()
+        );
+
+        //when
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Updated Title",
+                BASE_DATE.plusDays(1),
+                BASE_DATE.plusDays(20),
+                "Updated Content",
+                worker.getId(),
+                List.of(creator.getId()));
+        ProjectDetailResponse updateResponse = projectServiceApiV2
+                .updateProject(createResponse.getProjectId(), creator.getEmail(), updateRequest);
+        List<AttendantEntity> updateAttendants = attendantRepository
+                .findAllWithMemberAndProject(List.of(updateResponse.getProjectId())).orElseThrow();
+
+        //then
+        assertThat(updateResponse.getProjectTitle()).isEqualTo(updateRequest.projectTitle());
+        assertThat(updateResponse.getManagerName().name()).isEqualTo(worker.getName());
+        final int managerCount = 1;
+        assertThat(updateResponse.getAttendant().size() + managerCount).isEqualTo(updateAttendants.size());
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한을 가진 유저는 참여하지 않은 프로젝트 종료가 가능함.")
+    void closeProject_withAdminUser_shouldCloseProject() {
+        // given
+        MemberEntity creator = createMember("creator@test.com", "Creator");
+        MemberEntity pm = createMember("pm@test.com", "PM");
+        MemberEntity worker = createMember("worker@test.com", "worker");
+        MemberEntity admin = memberRepository.save(MemberEntity.builder()
+                .name("admin").email("admin@test.com").roleType(MemberRoleType.MASTER).build());
+
+        ProjectCreateResponse createResponse = projectServiceApiV2.createProjectV2(
+                createProjectRequest("Title", "Content", pm.getId(), List.of(worker.getId())),
+                creator.getEmail()
+        );
+        long projectId = createResponse.getProjectId();
+
+        //when + then
+        Assertions.assertDoesNotThrow(() -> projectServiceApiV2.closeProject(projectId, admin.getEmail()));
+        //then
+        List<AttendantEntity> attendantEntities = attendantRepository.findAllWithMemberAndProject(List.of(projectId)).orElseThrow();
+        ProjectEntity project = projectRepository.findById(projectId).orElseThrow();
+        assertThat(attendantEntities.size()).as("종료된 프로젝트에서는 참여자가 0명으로 조회되어야 함").isEqualTo(0);
+        assertThat(project.isClosed()).as("종료된 프로젝트는 종료 표시가 되어 있어야 함").isTrue();
+    }
+}

--- a/wise-office-server/src/test/java/kr/co/wise/office/domain/service/AttendantServiceTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/domain/service/AttendantServiceTest.java
@@ -1,0 +1,262 @@
+package kr.co.wise.office.domain.service;
+
+import kr.co.wise.office.domain.Project.dto.ProjectListResponse;
+import kr.co.wise.office.domain.Project.entity.ProjectEntity;
+import kr.co.wise.office.domain.attendant.entity.AttendantEntity;
+import kr.co.wise.office.domain.attendant.entity.AttendantRoleType;
+import kr.co.wise.office.domain.attendant.repository.AttendantRepository;
+import kr.co.wise.office.domain.attendant.service.AttendantService;
+import kr.co.wise.office.domain.member.entity.MemberEntity;
+import kr.co.wise.office.exception.ErrorMessage;
+import kr.co.wise.office.exception.custom.NotFoundResourceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AttendantServiceTest {
+
+    @InjectMocks
+    private AttendantService attendantService;
+
+    @Mock
+    private AttendantRepository attendantRepository;
+
+    @DisplayName("CREATOR, PM, WORKER가 모두 다른 경우, 각 역할에 맞게 참여자가 생성된다.")
+    @Test
+    void makeAttendantsV2_AllDistinctRoles() {
+        // given
+        MemberEntity creator = mock(MemberEntity.class);
+        lenient().when(creator.getId()).thenReturn(1L);
+        lenient().when(creator.getName()).thenReturn("Creator");
+
+        MemberEntity pm = mock(MemberEntity.class);
+        lenient().when(pm.getId()).thenReturn(2L);
+        lenient().when(pm.getName()).thenReturn("PM");
+
+        MemberEntity worker1 = mock(MemberEntity.class);
+        lenient().when(worker1.getId()).thenReturn(3L);
+        MemberEntity worker2 = mock(MemberEntity.class);
+        lenient().when(worker2.getId()).thenReturn(4L);
+
+        List<MemberEntity> workers = List.of(worker1, worker2);
+        ProjectEntity project = mock(ProjectEntity.class);
+
+        ArgumentCaptor<AttendantEntity> attendantCaptor = ArgumentCaptor.forClass(AttendantEntity.class);
+        ArgumentCaptor<List<AttendantEntity>> attendantsCaptor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        attendantService.makeAttendantsV2(creator, pm, workers, project);
+
+        // then
+        // 1. CREATOR와 PM이 각각 save 되는지 확인
+        verify(attendantRepository, times(2)).save(attendantCaptor.capture());
+        List<AttendantEntity> savedAttendants = attendantCaptor.getAllValues();
+        assertThat(savedAttendants).hasSize(2);
+        assertThat(savedAttendants).extracting(AttendantEntity::getRole).containsExactlyInAnyOrder(AttendantRoleType.CREATOR, AttendantRoleType.PM);
+
+        // 2. WORKER들이 saveAll로 저장되는지 확인
+        verify(attendantRepository, times(1)).saveAll(attendantsCaptor.capture());
+        List<AttendantEntity> savedWorkers = attendantsCaptor.getValue();
+        assertThat(savedWorkers).hasSize(2);
+        assertThat(savedWorkers).extracting(AttendantEntity::getRole).containsOnly(AttendantRoleType.WORKER);
+    }
+
+    @DisplayName("PM과 Creator가 동일인물일 경우, 반환되는 참여자 이름 목록에 중복이 없다.")
+    @Test
+    void makeAttendantsV2_SameCreatorAndPM() {
+        // given
+        MemberEntity sameUser = mock(MemberEntity.class);
+        lenient().when(sameUser.getId()).thenReturn(1L);
+        lenient().when(sameUser.getName()).thenReturn("SameUser");
+
+        MemberEntity worker1 = mock(MemberEntity.class);
+        lenient().when(worker1.getId()).thenReturn(3L);
+        lenient().when(worker1.getName()).thenReturn("Worker1");
+
+        MemberEntity worker2 = mock(MemberEntity.class);
+        lenient().when(worker2.getId()).thenReturn(4L);
+        lenient().when(worker2.getName()).thenReturn("Worker2");
+
+        List<MemberEntity> workers = List.of(worker1, worker2);
+        ProjectEntity project = mock(ProjectEntity.class);
+
+        // when
+        List<String> attendantNames = attendantService.makeAttendantsV2(sameUser, sameUser, workers, project);
+
+        // then
+        // PM과 Creator가 같으므로, 반환되는 이름 목록에는 worker1, worker2만 있어야 함
+        assertThat(attendantNames).hasSize(2);
+        assertThat(attendantNames).containsExactly("Worker1", "Worker2");
+        // PM save, Creator save
+        verify(attendantRepository, times(2)).save(any(AttendantEntity.class));
+        // worker save
+        verify(attendantRepository, times(1)).saveAll(anyList());
+    }
+
+    @DisplayName("프로젝트 참여자가 아닐 경우 NotFoundResourceException 예외가 발생한다.")
+    @Test
+    void validateParticipatingProject_NotParticipant_ShouldThrowException() {
+        // given
+        MemberEntity user = mock(MemberEntity.class);
+        ProjectEntity project = mock(ProjectEntity.class);
+        when(attendantRepository.findByMemberAndProject(user, project)).thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> attendantService.validateParticipatingProject(user, project))
+                .isInstanceOf(NotFoundResourceException.class)
+                .extracting("errorMessage")
+                .extracting("message")
+                .isEqualTo(ErrorMessage.NOT_FOUND_ATTENDANT.getMessage());
+    }
+
+    @DisplayName("프로젝트 참여자일 경우 해당 참여자 정보를 반환한다.")
+    @Test
+    void validateParticipatingProject_Participant_ShouldReturnAttendant() {
+        // given
+        MemberEntity user = mock(MemberEntity.class);
+        ProjectEntity project = mock(ProjectEntity.class);
+        AttendantEntity attendant = AttendantEntity.builder().role(AttendantRoleType.WORKER).build();
+        when(attendantRepository.findByMemberAndProject(user, project)).thenReturn(List.of(attendant));
+
+        // when
+        AttendantEntity result = attendantService.validateParticipatingProject(user, project);
+
+        // then
+        assertThat(result).isEqualTo(attendant);
+    }
+
+    @DisplayName("사용자가 PM과 CREATOR 역할을 모두 가질 경우, PM 권한을 우선하여 반환한다.")
+    @Test
+    void validateParticipatingProject_DualRole_ShouldReturnPMAttendant() {
+        // given
+        MemberEntity user = mock(MemberEntity.class);
+        ProjectEntity project = mock(ProjectEntity.class);
+        AttendantEntity creatorAttendant = AttendantEntity.builder().role(AttendantRoleType.CREATOR).build();
+        AttendantEntity pmAttendant = AttendantEntity.builder().role(AttendantRoleType.PM).build();
+        when(attendantRepository.findByMemberAndProject(user, project)).thenReturn(List.of(creatorAttendant, pmAttendant));
+
+        // when
+        AttendantEntity result = attendantService.validateParticipatingProject(user, project);
+
+        // then
+        assertThat(result.getRole()).isEqualTo(AttendantRoleType.PM);
+    }
+
+    @DisplayName("읽기용 - 프로젝트 참여자가 아닐 경우, 예외 없이 기본 WORKER 역할 객체를 반환한다.")
+    @Test
+    void validateParticipatingProjectForViewing_NotParticipant_ShouldReturnDefault() {
+        // given
+        MemberEntity user = mock(MemberEntity.class);
+        ProjectEntity project = mock(ProjectEntity.class);
+        when(attendantRepository.findByMemberAndProject(user, project)).thenReturn(List.of());
+
+        // when
+        AttendantEntity result = attendantService.validateParticipatingProjectForViewing(user, project);
+
+        // then
+        assertThat(result.getRole()).isEqualTo(AttendantRoleType.WORKER);
+    }
+
+    @DisplayName("프로젝트의 모든 참여자를 탈퇴 처리한다.")
+    @Test
+    void leaveAll_ShouldCallLeaveProjectOnAllAttendants() {
+        // given
+        ProjectEntity project = mock(ProjectEntity.class);
+        AttendantEntity attendant1 = AttendantEntity.builder().build();
+        AttendantEntity attendant2 = AttendantEntity.builder().build();
+        List<AttendantEntity> attendants = List.of(attendant1, attendant2);
+        when(attendantRepository.findAttendantsByProjectIdWithMember(project)).thenReturn(attendants);
+
+        // when
+        attendantService.leaveAll(project);
+
+        // then
+        assertThat(attendants).extracting("leftAt").doesNotContainNull();
+        verify(attendantRepository, times(1)).saveAll(attendants);
+    }
+
+    @DisplayName("프로젝트 참여자 업데이트 시, 기존 참여자는 탈퇴 처리되고 신규 참여자가 등록된다.")
+    @Test
+    void updateAttendants_ShouldUpdateCorrectly() {
+        // given
+        ProjectEntity project = mock(ProjectEntity.class);
+        MemberEntity oldPmMember = MemberEntity.builder().id(1L).name("old pm").email("oldPM@test.co.kr").build();
+        MemberEntity creatorMember = MemberEntity.builder().id(1L).name("creator").email("creator@test.co.kr").build();
+        MemberEntity newPmMember = MemberEntity.builder().id(2L).name("new pm").email("oldPM@test.co.kr").build();
+        MemberEntity workerMember = MemberEntity.builder().id(3L).name("worker pm").email("oldPM@test.co.kr").build();
+
+        AttendantEntity oldPmAttendant = AttendantEntity.builder()
+                .member(oldPmMember)
+                .role(AttendantRoleType.PM)
+                .build();
+        AttendantEntity creatorAttendant = AttendantEntity.builder()
+                .member(creatorMember)
+                .role(AttendantRoleType.CREATOR)
+                .build();
+
+        List<AttendantEntity> nowAttendants = List.of(oldPmAttendant, creatorAttendant);
+        when(attendantRepository.findAttendantsByProjectIdWithMember(project)).thenReturn(nowAttendants);
+
+        ArgumentCaptor<List<AttendantEntity>> newAttendantsCaptor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        attendantService.updateAttendants(project, newPmMember, List.of(workerMember, creatorMember));
+
+        // then
+        assertThat(oldPmAttendant.getLeftAt()).isNotNull();
+
+        verify(attendantRepository).saveAll(newAttendantsCaptor.capture());
+        List<AttendantEntity> savedNewAttendants = newAttendantsCaptor.getValue();
+        assertThat(savedNewAttendants).hasSize(3).as("새로운 PM, 새로운 참여자, CREATOR"); //newPM, worker, creator
+        assertThat(savedNewAttendants).extracting(AttendantEntity::getMember)
+                .containsExactlyInAnyOrder(newPmMember, workerMember, creatorMember);
+        assertThat(savedNewAttendants).extracting(AttendantEntity::getRole)
+                .containsExactlyInAnyOrder(AttendantRoleType.PM, AttendantRoleType.WORKER, AttendantRoleType.CREATOR);
+    }
+
+    @DisplayName("사용자가 참여중인 프로젝트 목록을 정확히 반환한다.")
+    @Test
+    void getProjectsByAttendants_ShouldReturnOnlyParticipatingProjects() {
+        // given
+        long loginUserId = 1L;
+        MemberEntity loginUser = mock(MemberEntity.class);
+        when(loginUser.getId()).thenReturn(loginUserId);
+
+        ProjectEntity project1 = mock(ProjectEntity.class);
+        lenient().when(project1.getId()).thenReturn(20L);
+        when(project1.getStartYear()).thenReturn(LocalDate.of(2025, 1, 1));
+        ProjectEntity project2 = mock(ProjectEntity.class);
+        lenient().when(project2.getId()).thenReturn(57L);
+        when(project2.getStartYear()).thenReturn(LocalDate.of(2025, 1, 1));
+
+        AttendantEntity attendant1 = AttendantEntity.builder().project(project1).build();
+        AttendantEntity attendant2 = AttendantEntity.builder().project(project2).build();
+        List<AttendantEntity> userAttendants = List.of(attendant1, attendant2);
+
+        when(attendantRepository.findAllByMemberId(loginUserId)).thenReturn(Optional.of(userAttendants));
+        // getAttendantsNameV2 내부 호출 Mocking
+        when(attendantRepository.findAllWithMemberAndProject(anyList())).thenReturn(Optional.of(List.of()));
+
+        // when
+        List<ProjectListResponse> result = attendantService.getProjectsByAttendants(loginUser);
+
+        // then
+        verify(attendantRepository, times(1)).findAllByMemberId(loginUserId);
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("projectId").containsExactlyInAnyOrder(20L, 57L);
+    }
+
+}


### PR DESCRIPTION
# 📝 PR Summary

- 프로젝트 상세 페이지에서 본인이 참여하지 않은 프로젝트의 세부 내역을 확인할 수 있도록 개선

### 🌲 Working Branch

<!-- 작업한 브랜치 이름 작성 -->

feat/#79-improve-project-detail-view

### 🌲 TODOs

<!-- 진행한 TODO List 작성 -->

-  [x] 상세 프로젝트 조회 기능 
-  [x] 로그 조회 기능  
-  [x] 댓글 조회 기능

### 📚 Remarks

<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->

- 기능 구현 도중 ADMIN이 로그 수정/생성이 되지 않는 문제가 있어 이를 수정했습니다. 83d6a57 6a670bd
- 중요 ServiceApi 및 Service Layer 의 테스트 코드를 작성했습니다.  beee20d 63a04e7 333baf5 9acb60d
- 프로젝트 생성, 수정시 제목 및 내용 길이(size)에 대한 검증 기능을 추가했습니다.  9258756
- 댓글 개수 집계시 삭제된 댓글 개수도 포함하여 계산하는 문제가 있어 이를 수정했습니다.  874e9e3

### Related Issues

<!-- 이슈 번호 작성 -->

resolve #79 

<!-- * @JakePark929 README작성. -->
