### PR TITLE
[FEATURE] 배포 자동화

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,38 @@
+name: DPG AutoDeployment # nextjs-spring-postgre를 전체 리빌딩합니다. 
+
+on:
+  # push:
+  #   branches: ["feat/#106-CI-CD"]
+  pull_request:
+    branches: ["dev"]
+    types: [closed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: connect server via to SSH
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.DPG_HOST}}
+          username: ${{secrets.DPG_USERNAME}}
+          key: ${{secrets.DPG_SSH_KEY}}
+          script: |
+            set -e
+
+            echo "🚚 서버 배포 중...."
+            cd ${{secrets.PROJECT_ROOT_PATH}}
+
+            git pull origin ${{github.ref_name}}
+
+            cd ./wise-office-infra
+
+            ./prod-env-stop.sh
+            echo "5초간 대기중..."
+            sleep(5)
+            ./prod-env.sh
+
+            echo "작업 완료!"
+
+


### PR DESCRIPTION
# 📝 PR Summary

- dev 브랜치로 merge 시 자동으로 재빌드가 되도록 수정했습니다.

### 🌲 Working Branch

<!-- 작업한 브랜치 이름 작성 -->

feat/#106-CI-CD

### 🌲 TODOs

<!-- 진행한 TODO List 작성 -->

-   [x] 깃허브 액선 yml 작성

### 📚 Remarks

<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->

- spring 서버 blue/green 배포까지는 구현됐으나, nextjs의 경우 차후 개발이 필요합니다. 
- 현재는 nextjs-spring-postgresql이 동시에 제거되고 재빌드되는 시스템으로, 재빌드시 잠깐의 서버 donwtime(1~2분)이 발생합니다.

### Related Issues

<!-- 이슈 번호 작성 -->

resolve #106 

<!-- * @JakePark929 README작성. -->
