### PR TITLE
[FEATURE] 회원가입 비밀번호 길이 제한

### DIFF
--- a/wise-office-client/src/components/signup/SignupInput.tsx
+++ b/wise-office-client/src/components/signup/SignupInput.tsx
@@ -23,6 +23,7 @@ export default function SignupInput({
                 name={id}
                 type={type}
                 value={value}
+                maxLength={20}
                 onChange={(e) => onChange(e.target.value)}
                 className="w-full px-3 py-2 mt-1 border border-gray-400 rounded-md outline-none"
             />

--- a/wise-office-client/src/pages/auth/signup.tsx
+++ b/wise-office-client/src/pages/auth/signup.tsx
@@ -52,6 +52,7 @@ export default function Signup() {
         team.trim() !== "" &&
         emailValid &&
         password.trim() !== "" &&
+        password.length > 7 &&
         passwordMatch.trim() !== "" &&
         password === passwordMatch;
 
@@ -220,7 +221,11 @@ export default function Signup() {
                         </span>
                     )}
                 </div>
-                {loading && <div>인증 코드 전송 중...</div>}
+                {loading && (
+                    <div className="text-sm text-gray-700">
+                        인증 코드 전송 중...
+                    </div>
+                )}
                 {isShowCodeInput && !emailValid && (
                     <div className="w-full px-4 mb-3">
                         <label
@@ -249,13 +254,20 @@ export default function Signup() {
                 )}
 
                 {/* Password */}
-                <SignupInput
-                    labelName="비밀번호"
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={setPassword}
-                />
+                <div className="w-full">
+                    <SignupInput
+                        labelName="비밀번호"
+                        id="password"
+                        type="password"
+                        value={password}
+                        onChange={setPassword}
+                    />
+                    {password.length > 0 && password.length < 8 && (
+                        <p className="mt-1 px-4 text-sm text-red-500">
+                            8자 이상 입력해 주세요. (최대 20자)
+                        </p>
+                    )}
+                </div>
                 <div className="w-full">
                     <SignupInput
                         labelName="비밀번호 확인"


### PR DESCRIPTION
# 📝 PR Summary

- 회원가입 비밀번호 입력 길이 제한

### 🌲 Working Branch

<!-- 작업한 브랜치 이름 작성 -->

feat/#135-password-limit

### 🌲 TODOs

<!-- 진행한 TODO List 작성 -->

- [x] 비밀번호 8 ~ 20 자 사이 일 경우 회원가입 버튼 활성화
- [x] 비밀번호 8자 이하일 경우 길이 제한 알림
- [x] 회원가입 페이지 모든 input 창 길이 제한 20자 설정

### 📚 Remarks

<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->

-

### Related Issues

<!-- 이슈 번호 작성 -->

resolve #135 

<!-- * @bbabbungtting README작성. -->
