### PR TITLE
[FEATURE] 연차계산 페이지 수정사항 반영

### DIFF
--- a/wise-office-client/src/components/leave-tracker/OutputSection/JoinDateField.tsx
+++ b/wise-office-client/src/components/leave-tracker/OutputSection/JoinDateField.tsx
@@ -18,17 +18,16 @@ export default function JoinDateField({
     onChange,
     page,
 }: SignupInputProps) {
-    const wrapperStyle = page === "account" ? "w-full" : "w-full px-4";
-    const labelStyle =
-        page === "account"
-            ? "block text-gray-700 font-semibold mb-2"
-            : "text-sm font-medium text-gray-700";
-
     return (
-        <div className={wrapperStyle}>
-            <label htmlFor={id} className={labelStyle}>
-                {labelName}
-            </label>
+        <div className="w-full">
+            {page !== "leave" && (
+                <label
+                    htmlFor={id}
+                    className="block text-gray-700 font-semibold mb-2"
+                >
+                    {labelName}
+                </label>
+            )}
             <div className="relative mt-1">
                 <Flatpickr
                     options={{

--- a/wise-office-client/src/components/leave-tracker/OutputSection/LeaveHistory.tsx
+++ b/wise-office-client/src/components/leave-tracker/OutputSection/LeaveHistory.tsx
@@ -23,11 +23,8 @@ export default function LeaveHistory({ thisYear, joinYear }: JoinYearProps) {
 
     return (
         <div>
-            <p className="font-bold text-gray-800 shrink-0 mb-4">
-                연도별 연차 사용 현황
-            </p>
             <ul>
-                {joinYear && inputData.length > 0 ? (
+                {inputData.length > 0 ? (
                     workingYears.map((year) => (
                         <li key={year}>
                             <SummaryList year={year} />
@@ -35,7 +32,7 @@ export default function LeaveHistory({ thisYear, joinYear }: JoinYearProps) {
                     ))
                 ) : (
                     <p className="text-sm text-gray-500">
-                        입사일을 입력해 연도별 연차 사용 내역을 확인하세요.
+                        연차 내역을 입력해 연도별 연차 사용 내역을 확인하세요.
                     </p>
                 )}
             </ul>

--- a/wise-office-client/src/components/leave-tracker/OutputSection/SummaryField.tsx
+++ b/wise-office-client/src/components/leave-tracker/OutputSection/SummaryField.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import SummaryCard from "./SummaryCard";
 import { useLeaveSummary } from "@/hooks/useLeaveSummary";
+import JoinDateField from "./JoinDateField";
 
 type JoinDateProps = {
     today: Date;
     joinDate: string;
+    setJoinDate: (joinDate: string) => void;
     thisYear: number;
     joinYear: number;
 };
@@ -13,6 +15,7 @@ type JoinDateProps = {
 export default function SummaryField({
     today,
     joinDate,
+    setJoinDate,
     thisYear,
     joinYear,
 }: JoinDateProps) {
@@ -28,10 +31,19 @@ export default function SummaryField({
     } = useLeaveSummary({ today, joinDate, thisYear, joinYear });
 
     return (
-        <div className="px-8">
-            <p className="font-bold text-gray-800 shrink-0 mb-4">
-                전체 연차 사용 현황
-            </p>
+        <div>
+            <div className="flex items-center gap-4 md:gap-10 mb-4">
+                <p className="font-bold text-gray-800 shrink-0">
+                    전체 연차 사용 현황
+                </p>
+                <JoinDateField
+                    id="hire-date"
+                    labelName="입사일"
+                    value={joinDate}
+                    onChange={setJoinDate}
+                    page="leave"
+                />
+            </div>
             {/* 상단 3개 */}
             <div className="grid grid-cols-3 gap-3">
                 <div className="">

--- a/wise-office-client/src/components/leave-tracker/OutputSection/index.tsx
+++ b/wise-office-client/src/components/leave-tracker/OutputSection/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import LeaveHistory from "./LeaveHistory";
 import SummaryField from "./SummaryField";
 import { getJoinDate } from "@/services/members";
@@ -7,28 +7,47 @@ export default function OutputSection() {
     const [joinDate, setJoinDate] = useState<string>("");
 
     useEffect(() => {
-        getJoinDate().then((date) => setJoinDate(date));
+        getJoinDate()
+            .then((date) => setJoinDate(date))
+            .catch(() => setJoinDate(""));
     }, []);
 
     const today = new Date();
-    const thisYear = Number(today.getFullYear());
-    const joinYear = Number(joinDate.split("-")[0]) || thisYear;
+    const thisYear = today.getFullYear();
+    const joinYear = useMemo(() => {
+        if (!joinDate) return undefined;
+        return Number(joinDate.split("-")[0]);
+    }, [joinDate]);
 
     return (
-        <div className="w-full h-full bg-white border border-gray-200 rounded-lg shadow-sm flex flex-col overflow-hidden">
-            <div className="sticky top-0 z-10 -mx-8 bg-white border-b border-gray-200 shadow-[0_2px_0_0_rgba(0,0,0,0.03)]">
+        <div className="w-full h-full bg-white border border-gray-200 rounded-lg shadow-sm flex flex-col overflow-hidden ">
+            <div className="sticky top-0 z-10 bg-white border-b border-gray-200 shadow-[0_2px_0_0_rgba(0,0,0,0.03)]">
                 <div className="p-8 pb-4">
                     <SummaryField
                         today={today}
                         joinDate={joinDate}
+                        setJoinDate={setJoinDate}
                         thisYear={thisYear}
-                        joinYear={joinYear}
+                        joinYear={joinYear ?? thisYear}
                     />
                 </div>
             </div>
 
-            <div className="flex-1 min-h-0 px-8 py-6 overflow-y-auto scrollbar-auto-hide overscroll-contain">
-                <LeaveHistory thisYear={thisYear} joinYear={joinYear} />
+            <div className="flex-1 min-h-0 flex flex-col">
+                <div className="bg-white px-8 py-4">
+                    <p className="font-bold text-gray-900 text-lg">
+                        연도별 연차 사용 현황
+                    </p>
+                </div>
+                <div className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide overscroll-contain px-8 pb-4">
+                    {joinYear !== undefined ? (
+                        <LeaveHistory thisYear={thisYear} joinYear={joinYear} />
+                    ) : (
+                        <p className="text-sm text-gray-500">
+                            입사일을 입력해 연도별 연차 사용 내역을 확인하세요.
+                        </p>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/wise-office-client/src/hooks/useLeaveSummary.ts
+++ b/wise-office-client/src/hooks/useLeaveSummary.ts
@@ -5,11 +5,25 @@ const DEDUCTION = new Set(["연차", "반차(오후)", "반차(오전)", "반반
 const SUBSTITUTE = new Set(["대체반차(오전)", "대체반차(오후)", "대체"]);
 const DEFENSE = new Set(["국방(반차)", "국방"]);
 
-function isOverOneYear(today: Date, joinDate: string) {
-    const d = new Date(joinDate);
-    const plusOneYear = new Date(d);
-    plusOneYear.setFullYear(plusOneYear.getFullYear() + 1);
-    return today >= plusOneYear;
+function workingYears(start: Date, end: Date): number {
+    if (end < start) return 0;
+    let years = end.getFullYear() - start.getFullYear();
+    if (
+        end.getMonth() < start.getMonth() ||
+        (end.getMonth() === start.getMonth() && end.getDate() < start.getDate())
+    ) {
+        years -= 1;
+    }
+    return Math.max(0, years);
+}
+
+function workingMonths(start: Date, end: Date): number {
+    if (end < start) return 0;
+    let months =
+        (end.getFullYear() - start.getFullYear()) * 12 +
+        (end.getMonth() - start.getMonth());
+    if (end.getDate() < start.getDate()) months -= 1;
+    return Math.max(0, months);
 }
 
 export function useLeaveSummary(params: {
@@ -33,9 +47,31 @@ export function useLeaveSummary(params: {
             };
         }
 
-        const annualAvailable = isOverOneYear(today, joinDate)
-            ? 11 + (thisYear - joinYear) * 15
-            : 11;
+        const joinDate_Date = joinDate ? new Date(joinDate) : undefined;
+
+        let diffDays: number | undefined = undefined;
+        if (joinDate_Date) {
+            const diffMs = today.getTime() - joinDate_Date.getTime();
+            diffDays = Math.floor(diffMs / 86_400_000); // 하루의 밀리초
+        }
+
+        // joinDate가 없거나 미래 : annualAvailable = 0
+        let annualAvailable = 0;
+        if (!joinDate_Date || today < joinDate_Date) {
+            annualAvailable = 0;
+        } else {
+            // 근속년수 계산
+            const years = workingYears(joinDate_Date, today);
+
+            if (years < 1) {
+                // 1년 미만 : 월차
+                const n = workingMonths(joinDate_Date, today);
+                annualAvailable = n;
+            } else {
+                // 1년 이상: 연차 (+15)
+                annualAvailable = 11 + years * 15;
+            }
+        }
 
         const sums = inputData.reduce(
             (acc, row) => {

--- a/wise-office-client/src/hooks/useLeaveSummary.ts
+++ b/wise-office-client/src/hooks/useLeaveSummary.ts
@@ -49,12 +49,6 @@ export function useLeaveSummary(params: {
 
         const joinDate_Date = joinDate ? new Date(joinDate) : undefined;
 
-        let diffDays: number | undefined = undefined;
-        if (joinDate_Date) {
-            const diffMs = today.getTime() - joinDate_Date.getTime();
-            diffDays = Math.floor(diffMs / 86_400_000); // 하루의 밀리초
-        }
-
         // joinDate가 없거나 미래 : annualAvailable = 0
         let annualAvailable = 0;
         if (!joinDate_Date || today < joinDate_Date) {

--- a/wise-office-client/src/pages/auth/signup.tsx
+++ b/wise-office-client/src/pages/auth/signup.tsx
@@ -15,7 +15,6 @@ import {
     handleCodeVerify,
     handleSummitSignUpForm,
 } from "@/hooks/handleSignup";
-import JoinDateField from "@/components/leave-tracker/OutputSection/JoinDateField";
 
 const RANK = ["직급을 선택해 주세요", "주임", "선임", "팀장", "수석"];
 const TEAM = ["소속을 선택해 주세요", "연구기획 1팀", "연구기획 2팀"];
@@ -27,7 +26,6 @@ export default function Signup() {
     const [name, setName] = useState("");
     const [rank, setRank] = useState("");
     const [team, setTeam] = useState("");
-    const [hireDate, setHireDate] = useState("");
 
     // Email
     const [email, setEmail] = useState("");
@@ -52,7 +50,6 @@ export default function Signup() {
         name.trim() !== "" &&
         rank.trim() !== "" &&
         team.trim() !== "" &&
-        hireDate &&
         emailValid &&
         password.trim() !== "" &&
         password.length > 7 &&
@@ -116,7 +113,6 @@ export default function Signup() {
             team,
             rank,
             email,
-            hireDate,
         };
 
         const success = await handleSummitSignUpForm(signupInputData);
@@ -176,14 +172,6 @@ export default function Signup() {
                     options={TEAM}
                     value={team}
                     onChange={setTeam}
-                />
-
-                <JoinDateField
-                    id="hire-date"
-                    labelName="입사일"
-                    value={hireDate}
-                    onChange={setHireDate}
-                    page="signup"
                 />
 
                 {/* Email */}

--- a/wise-office-client/src/types/member.ts
+++ b/wise-office-client/src/types/member.ts
@@ -12,5 +12,4 @@ export interface SignupForm {
     team: string;
     rank: string;
     email: string;
-    hireDate: string;
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/SignupRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/SignupRequest.java
@@ -2,7 +2,6 @@ package kr.co.wise.office.domain.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import kr.co.wise.office.api.validation.annotation.ValidPassword;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -15,6 +14,6 @@ public record SignupRequest(@NotBlank(message = "{notBlank}") String name,
                             @NotBlank(message = "{notBlank}") String team,
                             @NotBlank(message = "{notBlank}") String rank,
                             @NotBlank(message = "{notBlank}") @Email(message = "{login.email}") String email,
-                            @DateTimeFormat(pattern = "yyyy-MM-dd") @NotNull(message = "{notBlank}") LocalDate hireDate,
+                            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate hireDate,
                             String profileImage) {
 }

--- a/wise-office-server/src/test/java/kr/co/wise/office/api/MemberControllerTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/api/MemberControllerTest.java
@@ -233,7 +233,7 @@ public class MemberControllerTest {
         }
 
         @Test
-        @DisplayName("실패: 입사일자 미입력")
+        @DisplayName("성공: 입사일자 미입력")
         void signup_Fail_emptyHireDate() throws Exception {
             // given: 입사일자 미입력
             SignupRequest signupRequest = createRequestFormWithHireDate(null);
@@ -241,8 +241,11 @@ public class MemberControllerTest {
 
             // then
             mockMvc.perform(multipart("/api/members/signup").file(jsonRequest))
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isOk())
                     .andDo(print());
+
+            MemberEntity member = memberRepository.findByEmail(email).get();
+            assertThat(member.getHireDate()).isNull();
         }
     }
 


### PR DESCRIPTION
# 📝 PR Summary

- 연차계산 페이지의 수정사항 내용 적용

### 🌲 Working Branch

<!-- 작업한 브랜치 이름 작성 -->

feat#175-leave-tracker-change

### 🌲 TODOs

<!-- 진행한 TODO List 작성 -->

-   [x] 입사일을 등록하지 않은 경우 연차계산 페이지에서 입력 가능 (저장되지 않음)
- [x] "연도별 연차 사용 내역" 제목 고정
- [x] 1년 미만인 경우 입사일 이후로 달마다 `+1`개 되도록 수정
- [x] 회원가입 시 입사일자 등록은 비필수

### 📚 Remarks

<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->

-

### Related Issues

<!-- 이슈 번호 작성 -->

resolve #175 

<!-- * @JakePark929 README작성. -->
