### PR TITLE
[FEATURE] overview 페이지 연도별 프로젝트 리스트 API 작성 및 연결

### DIFF
--- a/wise-office-client/src/components/modal/PreviewModal/index.tsx
+++ b/wise-office-client/src/components/modal/PreviewModal/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Buttonbar from "./Buttonbar";
-import { usePreview } from "@/store/useOverviewStore";
+import { usePreviewStore } from "@/store/useOverviewStore";
 
 const A4_WIDTH = 595;
 const A4_HEIGHT = Math.round(595 * Math.SQRT2);
@@ -9,7 +9,7 @@ const MODAL_PADDING = 32;
 const HEADER_FOOTER_HEIGHT = 64;
 
 export default function PreviewModal() {
-    const { onClose } = usePreview();
+    const { onClose } = usePreviewStore();
     const [scale, setScale] = useState(1);
 
     useEffect(() => {

--- a/wise-office-client/src/components/overview/Calendar.tsx
+++ b/wise-office-client/src/components/overview/Calendar.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef } from "react";
-import { useOverview } from "@/store/useOverviewStore";
+import { useOverviewStore } from "@/store/useOverviewStore";
 import { menus } from "@/lib/data/overview";
 
 const days = ["일", "월", "화", "수", "목", "금", "토"];
 
 export default function Calendar() {
     const years = menus.map((m) => m.year).sort((a, b) => b - a);
-    const { year, month, setYear, setMonth } = useOverview();
+    const { year, month, setYear, setMonth } = useOverviewStore();
 
     const [openYear, setOpenYear] = useState(false);
     const [openMonth, setOpenMonth] = useState(false);

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -1,9 +1,9 @@
 import OverviewCard from "./OverviewCard";
-import { useOverview } from "@/store/useOverviewStore";
+import { useOverviewStore } from "@/store/useOverviewStore";
 import { MINUTES } from "@/lib/data/overview";
 
 export default function MonthOverviewList() {
-    const { year, month } = useOverview();
+    const { year, month } = useOverviewStore();
 
     const filteredData = MINUTES.filter(
         (m) =>

--- a/wise-office-client/src/components/overview/ProjectMenu.tsx
+++ b/wise-office-client/src/components/overview/ProjectMenu.tsx
@@ -1,13 +1,26 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Folder, FolderOpen } from "lucide-react";
-import { useOverview } from "@/store/useOverviewStore";
-import { menus } from "@/lib/data/overview";
+import {
+    useOverviewStore,
+    useProjectsGroupByYearStore,
+} from "@/store/useOverviewStore";
 
 export default function ProjectMenu() {
-    const { year, projectId, setYear, setProjectId } = useOverview();
-    const [openYear, setOpenYear] = useState<number[]>([
-        Math.max(...menus.map((m) => m.year)),
-    ]);
+    const { year, projectId, setYear, setProjectId } = useOverviewStore();
+    const { groupByYear, fetchGroupByYear } = useProjectsGroupByYearStore();
+
+    const [openYear, setOpenYear] = useState<number[]>([]);
+
+    useEffect(() => {
+        fetchGroupByYear();
+    }, [fetchGroupByYear]);
+
+    useEffect(() => {
+        if (groupByYear.length > 0) {
+            const latestYear = Math.max(...groupByYear.map((m) => m.year));
+            setOpenYear([latestYear]);
+        }
+    }, [groupByYear]);
 
     const selectYear = (year: number) => {
         setOpenYear((prev) =>
@@ -18,8 +31,8 @@ export default function ProjectMenu() {
     };
 
     const sortedMenus = useMemo(
-        () => [...menus].sort((a, b) => b.year - a.year),
-        [],
+        () => [...groupByYear].sort((a, b) => b.year - a.year),
+        [groupByYear],
     );
 
     return (
@@ -47,16 +60,16 @@ export default function ProjectMenu() {
 
                         {openYear.includes(menu.year) && (
                             <ul className="ml-10 cursor-pointer">
-                                {menu.items.map((item) => (
+                                {menu.projects.map((item) => (
                                     <li
-                                        key={item.project_pk}
-                                        className={`px-3 py-1 mb-1 text-sm rounded-md hover:bg-gray-100 hover:font-medium ${item.project_pk === projectId && menu.year === year ? "bg-gray-100 font-medium" : ""}`}
+                                        key={item.projectId}
+                                        className={`px-3 py-1 mb-1 text-sm rounded-md hover:bg-gray-100 hover:font-medium ${item.projectId === projectId && menu.year === year ? "bg-gray-100 font-medium" : ""}`}
                                         onClick={() => {
-                                            setProjectId(item.project_pk);
+                                            setProjectId(item.projectId);
                                             setYear(menu.year);
                                         }}
                                     >
-                                        {item.title}
+                                        {item.projectTitle}
                                     </li>
                                 ))}
                             </ul>

--- a/wise-office-client/src/components/overview/ProjectMenu.tsx
+++ b/wise-office-client/src/components/overview/ProjectMenu.tsx
@@ -16,11 +16,11 @@ export default function ProjectMenu() {
     }, [fetchGroupByYear]);
 
     useEffect(() => {
-        if (groupByYear.length > 0) {
+        if (groupByYear.length > 0 && openYear.length === 0) {
             const latestYear = Math.max(...groupByYear.map((m) => m.year));
             setOpenYear([latestYear]);
         }
-    }, [groupByYear]);
+    }, [groupByYear, openYear]);
 
     const selectYear = (year: number) => {
         setOpenYear((prev) =>

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -1,9 +1,9 @@
-import { useOverview } from "@/store/useOverviewStore";
+import { useOverviewStore } from "@/store/useOverviewStore";
 import OverviewCard from "./OverviewCard";
 import { MINUTES, projectNames } from "@/lib/data/overview";
 
 export default function ProjectOverviewList() {
-    const { year, projectId } = useOverview();
+    const { year, projectId } = useOverviewStore();
 
     const projectName = projectNames.find(
         (m) => m.project_pk === projectId,

--- a/wise-office-client/src/components/ui/button/PreviewButton.tsx
+++ b/wise-office-client/src/components/ui/button/PreviewButton.tsx
@@ -1,8 +1,8 @@
-import { usePreview } from "@/store/useOverviewStore";
+import { usePreviewStore } from "@/store/useOverviewStore";
 import { LucideFileSearch } from "lucide-react";
 
 export default function PreviewButton() {
-    const { onOpen } = usePreview();
+    const { onOpen } = usePreviewStore();
 
     return (
         <button

--- a/wise-office-client/src/components/ui/toggle/MenuToggle.tsx
+++ b/wise-office-client/src/components/ui/toggle/MenuToggle.tsx
@@ -1,8 +1,8 @@
-import { useOverview } from "@/store/useOverviewStore";
+import { useOverviewStore } from "@/store/useOverviewStore";
 import { Calendar1, Folder } from "lucide-react";
 
 export default function MenuToggle() {
-    const { optionIndex, setOptionIndex } = useOverview();
+    const { optionIndex, setOptionIndex } = useOverviewStore();
 
     const options = [
         { name: "프로젝트", icon: <Folder size={18} strokeWidth={1.5} /> },

--- a/wise-office-client/src/pages/overview/index.tsx
+++ b/wise-office-client/src/pages/overview/index.tsx
@@ -4,11 +4,11 @@ import Calendar from "@/components/overview/Calendar";
 import ProjectOverviewList from "@/components/overview/ProjectOverviewList";
 import MonthOverviewList from "@/components/overview/MonthOverviewList";
 import PreviewModal from "@/components/modal/PreviewModal";
-import { useOverview, usePreview } from "@/store/useOverviewStore";
+import { useOverviewStore, usePreviewStore } from "@/store/useOverviewStore";
 
 export default function Overview() {
-    const { optionIndex } = useOverview();
-    const { isOpen } = usePreview();
+    const { optionIndex } = useOverviewStore();
+    const { isOpen } = usePreviewStore();
 
     return (
         <div className="min-h-screen flex mx-24 my-16 gap-16">

--- a/wise-office-client/src/services/projects.ts
+++ b/wise-office-client/src/services/projects.ts
@@ -1,5 +1,10 @@
 import { api } from "@/lib/clientApi";
-import type { Project, ProjectInfo, CreateProject } from "@/types/project";
+import type {
+    Project,
+    ProjectInfo,
+    CreateProject,
+    ProjectGroupByYear,
+} from "@/types/project";
 
 import { PageInfo, PageParams } from "@/types/page";
 
@@ -24,6 +29,13 @@ export async function getCurrentPageProjects({
         },
     });
     return res.data;
+}
+
+export async function getProjectsGroupByYear(): Promise<ProjectGroupByYear[]> {
+    const { data } = await api.get<ProjectGroupByYear[]>(
+        "v3/projects/groupByYear",
+    );
+    return data;
 }
 
 /**

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 import { MINUTES } from "@/lib/data/overview";
+import { ProjectGroupByYear } from "@/types/project";
+import { getProjectsGroupByYear } from "@/services/projects";
 
 const today = new Date();
 
@@ -15,7 +17,7 @@ type OverviewState = {
     setProjectId: (projectId: number) => void;
 };
 
-export const useOverview = create<OverviewState>((set) => ({
+export const useOverviewStore = create<OverviewState>((set) => ({
     optionIndex: 0,
     year:
         MINUTES.length > 0
@@ -31,6 +33,26 @@ export const useOverview = create<OverviewState>((set) => ({
     setProjectId: (projectId) => set({ projectId }),
 }));
 
+// 연도별 프로젝트 메뉴
+interface ProjectGroupByYearState {
+    groupByYear: ProjectGroupByYear[];
+    fetchGroupByYear: () => Promise<void>;
+}
+
+export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
+    (set) => ({
+        groupByYear: [],
+
+        fetchGroupByYear: async () => {
+            const data = await getProjectsGroupByYear();
+
+            set({
+                groupByYear: Array.isArray(data) ? data : [],
+            });
+        },
+    }),
+);
+
 // 미리보기 모달 상태
 type PreviewState = {
     isOpen: boolean;
@@ -40,7 +62,7 @@ type PreviewState = {
     onClose: () => void;
 };
 
-export const usePreview = create<PreviewState>((set) => ({
+export const usePreviewStore = create<PreviewState>((set) => ({
     isOpen: false,
     setIsOpen: (isOpen) => set({ isOpen }),
 

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -47,7 +47,9 @@ export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
             const data = await getProjectsGroupByYear();
 
             set({
-                groupByYear: Array.isArray(data) ? data : [],
+                groupByYear: Array.isArray(data)
+                    ? data.filter((item) => item.year <= today.getFullYear())
+                    : [],
             });
         },
     }),

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -48,7 +48,9 @@ export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
 
             set({
                 groupByYear: Array.isArray(data)
-                    ? data.filter((item) => item.year <= today.getFullYear())
+                    ? data.filter(
+                          (item) => item.year <= new Date().getFullYear(),
+                      )
                     : [],
             });
         },

--- a/wise-office-client/src/types/project.ts
+++ b/wise-office-client/src/types/project.ts
@@ -47,6 +47,16 @@ export interface CreateProject {
     proposalAttendants: number[];
 }
 
+export interface ProjectItem {
+    projectId: number;
+    projectTitle: string;
+}
+
+export interface ProjectGroupByYear {
+    year: number;
+    projects: ProjectItem[];
+}
+
 export type DocumentType = "log" | "minute" | "approve";
 
 export type SelectedDocument = { type: DocumentType; id: number };

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/ProjectControllerV3.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/ProjectControllerV3.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.wise.office.application.ProjectServiceApiV3;
 import kr.co.wise.office.domain.Project.dto.ProjectListResponse;
 import kr.co.wise.office.domain.Project.dto.ProjectListResponseWithPaging;
+import kr.co.wise.office.domain.Project.dto.ProjectGroupByYearResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @AllArgsConstructor
@@ -39,6 +42,16 @@ public class ProjectControllerV3 {
                                                                           @RequestParam(name = "offset", defaultValue = "6") int offset) {
 
         return ResponseEntity.status(HttpStatus.OK).body(projectServiceApiV3.getProjectInfoWithPaging(page-1, offset));
+    }
+
+    @Operation(summary = "프로젝트 연도별 조회", description = "연도별로 프로젝트 리스트를 조회합니다")
+    @GetMapping("/groupByYear")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로젝트 조회 성공. 연도별 프로젝트 리스트가 반환됩니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = ProjectListResponse.class)))),
+    })
+    public ResponseEntity<List<ProjectGroupByYearResponse>> getProjectsGroupByYear() {
+        return ResponseEntity.status(HttpStatus.OK).body(projectServiceApiV3.getProjectsGroupByYear());
     }
 
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/ProjectControllerV3.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/ProjectControllerV3.java
@@ -48,7 +48,7 @@ public class ProjectControllerV3 {
     @GetMapping("/groupByYear")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로젝트 조회 성공. 연도별 프로젝트 리스트가 반환됩니다.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = ProjectListResponse.class)))),
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = ProjectGroupByYearResponse.class)))),
     })
     public ResponseEntity<List<ProjectGroupByYearResponse>> getProjectsGroupByYear() {
         return ResponseEntity.status(HttpStatus.OK).body(projectServiceApiV3.getProjectsGroupByYear());

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/ProjectServiceApiV3.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/ProjectServiceApiV3.java
@@ -3,6 +3,7 @@ package kr.co.wise.office.application;
 import kr.co.wise.office.domain.Project.Service.ProjectService;
 import kr.co.wise.office.domain.Project.dto.ProjectListResponse;
 import kr.co.wise.office.domain.Project.dto.ProjectListResponseWithPaging;
+import kr.co.wise.office.domain.Project.dto.ProjectGroupByYearResponse;
 import kr.co.wise.office.domain.Project.entity.ProjectEntity;
 import kr.co.wise.office.domain.attendant.service.AttendantService;
 import kr.co.wise.office.domain.member.service.MemberService;
@@ -37,4 +38,8 @@ public class ProjectServiceApiV3 {
         return new ProjectListResponseWithPaging(pageNationInfo, projectListResponses);
     }
 
+    @Transactional(readOnly = true)
+    public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
+        return projectService.getProjectsGroupByYear();
+    }
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/config/SecurityConfig.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/login/oauth2/code/google", "/oauth2/**", "/health", "/swagger-ui/**",
                         "/v3/api-docs/**", "/api/members/signup", "/api/members/login", "/api/v2/projects",
-                        "/api/members/emails/verification", "/swagger-ui.html", "/api/v3/projects",
+                        "/api/members/emails/verification", "/swagger-ui.html", "/api/v3/projects", "api/v3/projects/groupByYear",
                         "/images/**", "/github-action")
                 .permitAll()
                 .anyRequest().authenticated());

--- a/wise-office-server/src/main/java/kr/co/wise/office/config/SecurityConfig.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**", "/login/oauth2/code/google", "/oauth2/**", "/health", "/swagger-ui/**",
                         "/v3/api-docs/**", "/api/members/signup", "/api/members/login", "/api/v2/projects",
-                        "/api/members/emails/verification", "/swagger-ui.html", "/api/v3/projects", "api/v3/projects/groupByYear",
+                        "/api/members/emails/verification", "/swagger-ui.html", "/api/v3/projects", "/api/v3/projects/groupByYear",
                         "/images/**", "/github-action")
                 .permitAll()
                 .anyRequest().authenticated());

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -98,5 +100,23 @@ public class ProjectService {
     public Page<ProjectEntity> searchProjectWithManagerWithPaging(PageRequest pageable) {
         Page<ProjectEntity> projectsWithPaging = projectRepository.findProjectsWithPaging(pageable);
         return projectsWithPaging;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
+        return projectRepository.findAllOrderByYearAndPk()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        p -> p.getStartYear().getYear()
+                ))
+                .entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new ProjectGroupByYearResponse(
+                        entry.getKey(),
+                        entry.getValue().stream()
+                                .map(ProjectGroupByYearResponse.ProjectItem::new)
+                                .toList()
+                ))
+                .toList();
     }
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
@@ -102,21 +102,33 @@ public class ProjectService {
         return projectsWithPaging;
     }
 
-    @Transactional(readOnly = true)
-    public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
-        return projectRepository.findAllOrderByYearAndPk()
-                .stream()
-                .collect(Collectors.groupingBy(
-                        p -> p.getStartYear().getYear()
-                ))
-                .entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(entry -> new ProjectGroupByYearResponse(
-                        entry.getKey(),
-                        entry.getValue().stream()
-                                .map(ProjectGroupByYearResponse.ProjectItem::new)
-                                .toList()
-                ))
-                .toList();
-    }
+   @Transactional(readOnly = true)
+public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
+
+    return projectRepository.findAllOrderByYearAndPk()
+            .stream()
+            .flatMap(project -> {
+
+                int start = project.getStartYear().getYear();
+                int end = project.getEndYear().getYear();
+
+                return java.util.stream.IntStream.rangeClosed(start, end)
+                        .mapToObj(year -> Map.entry(year, project));
+            })
+            .collect(Collectors.groupingBy(
+                    Map.Entry::getKey,
+                    Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+            ))
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.<Integer, List<ProjectEntity>>comparingByKey().reversed())
+            .map(entry -> new ProjectGroupByYearResponse(
+                    entry.getKey(),
+                    entry.getValue()
+                            .stream()
+                            .map(ProjectGroupByYearResponse.ProjectItem::new)
+                            .toList()
+            ))
+            .toList();
+}
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @AllArgsConstructor
@@ -104,15 +106,27 @@ public class ProjectService {
 
    @Transactional(readOnly = true)
 public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
+    final int MAX_YEAR_RANGE = 100; // 안전 범위 제한
 
     return projectRepository.findAllOrderByYearAndPk()
             .stream()
             .flatMap(project -> {
+                if (project.getStartYear() == null || project.getEndYear() == null) {
+                    return Stream.empty();
+                }
 
                 int start = project.getStartYear().getYear();
                 int end = project.getEndYear().getYear();
 
-                return java.util.stream.IntStream.rangeClosed(start, end)
+                if (start > end) {
+                    return Stream.empty();
+                }
+
+                if (end - start > MAX_YEAR_RANGE) {
+                    end = start + MAX_YEAR_RANGE;
+                }
+
+                return IntStream.rangeClosed(start, end)
                         .mapToObj(year -> Map.entry(year, project));
             })
             .collect(Collectors.groupingBy(

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectGroupByYearResponse.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/dto/ProjectGroupByYearResponse.java
@@ -1,0 +1,29 @@
+package kr.co.wise.office.domain.Project.dto;
+
+import kr.co.wise.office.domain.Project.entity.ProjectEntity;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProjectGroupByYearResponse {
+
+    private final int year;
+    private final List<ProjectItem> projects;
+
+    public ProjectGroupByYearResponse(int year, List<ProjectItem> projects) {
+        this.year = year;
+        this.projects = projects;
+    }
+
+    @Getter
+    public static class ProjectItem {
+        private final long projectId;
+        private final String projectTitle;
+
+        public ProjectItem(ProjectEntity project) {
+            this.projectId = project.getId();
+            this.projectTitle = project.getTitle();
+        }
+    }
+}

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/repository/ProjectRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/repository/ProjectRepository.java
@@ -25,6 +25,6 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
            countQuery = "select count(p) from ProjectEntity p where p.closed = false")
     Page<ProjectEntity> findProjectsWithPaging(Pageable pageable);
 
-    @Query("SELECT p FROM ProjectEntity p JOIN FETCH p.member WHERE p.closed = false ORDER BY YEAR(p.startYear) ASC, p.id ASC")
+    @Query("SELECT p FROM ProjectEntity p JOIN FETCH p.member WHERE p.closed = false ORDER BY p.startYear ASC, p.id ASC")
     List<ProjectEntity> findAllOrderByYearAndPk();
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/repository/ProjectRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/repository/ProjectRepository.java
@@ -24,4 +24,7 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
     @Query(value = "select p from ProjectEntity p join fetch p.member where p.closed = false",
            countQuery = "select count(p) from ProjectEntity p where p.closed = false")
     Page<ProjectEntity> findProjectsWithPaging(Pageable pageable);
+
+    @Query("SELECT p FROM ProjectEntity p JOIN FETCH p.member WHERE p.closed = false ORDER BY YEAR(p.startYear) ASC, p.id ASC")
+    List<ProjectEntity> findAllOrderByYearAndPk();
 }


### PR DESCRIPTION
# 📝 PR Summary
- overview 페이지에서 연도별로 프로젝트 리스트를 조회할 수 있는 API를 작성하고 연결함

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#220-group-by-year

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 연도별 프로젝트 리스트 API 작성
- [x] 왼쪽 메뉴 리스트와 연동

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
- 트리 메뉴에 임시 데이터 제거함

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #220 

<!-- * @JakePark929 README작성. -->
