### PR TITLE
[FEATURE] overview 페이지에서 회의록/품의서 조회 API 연동

### DIFF
--- a/wise-office-client/src/components/document/LabelCell.tsx
+++ b/wise-office-client/src/components/document/LabelCell.tsx
@@ -2,7 +2,7 @@ export function LabelCell({ label }: { label: string }) {
     const characters = label.split("");
 
     return (
-        <td className="border border-black px-[10px] py-2 bg-gray-300 font-semibold text-black text-[14px] align-middle">
+        <td className="border border-black px-[10px] bg-gray-300 font-semibold text-black text-[14px] align-middle">
             <div className="flex justify-between w-full">
                 {characters.map((char, index) => (
                     <span key={index}>{char}</span>

--- a/wise-office-client/src/components/document/MinuteDocument.tsx
+++ b/wise-office-client/src/components/document/MinuteDocument.tsx
@@ -3,8 +3,10 @@ import ApprovalSeal from "./ApprovalSeal";
 import { usePreviewStore } from "@/store/useOverviewStore";
 import { ReadableCell } from "./ReadableCell";
 
-export default function MinutePreview() {
+export default function MinuteDocument() {
     const { minutesInfo } = usePreviewStore();
+
+    console.log("000", minutesInfo);
 
     if (!minutesInfo) return null;
 

--- a/wise-office-client/src/components/document/MinuteDocument.tsx
+++ b/wise-office-client/src/components/document/MinuteDocument.tsx
@@ -8,6 +8,8 @@ export default function MinuteDocument() {
 
     if (!minutesInfo) return null;
 
+    console.log(minutesInfo);
+
     return (
         <div className="bg-white w-full max-w-[720px] min-h-[1020px] h-full px-[80px] pt-[92px] pb-[120px] flex flex-col">
             {/* 결제 란 */}
@@ -75,7 +77,7 @@ export default function MinuteDocument() {
                         <ReadableCell
                             colSpan={3}
                             value={minutesInfo.minutesAttendants}
-                            style={"text-start"}
+                            textAlign={"text-start"}
                         />
                     </tr>
                     <tr>
@@ -83,7 +85,7 @@ export default function MinuteDocument() {
                         <ReadableCell
                             colSpan={3}
                             value={minutesInfo.writer}
-                            style={"text-start"}
+                            textAlign={"text-start"}
                         />
                     </tr>
                     <tr className="h-4"></tr>
@@ -94,7 +96,8 @@ export default function MinuteDocument() {
                 회 의 내 용
             </div>
             <textarea
-                value={minutesInfo.meetingContent}
+                value={minutesInfo.content}
+                readOnly
                 className="w-full border border-t-0 border-black p-4 text-sm leading-relaxed 
                         text-slate-800 resize-none overflow-hidden focus:outline-none rounded-b flex-1"
             />

--- a/wise-office-client/src/components/document/MinuteDocument.tsx
+++ b/wise-office-client/src/components/document/MinuteDocument.tsx
@@ -8,8 +8,6 @@ export default function MinuteDocument() {
 
     if (!minutesInfo) return null;
 
-    console.log(minutesInfo);
-
     return (
         <div className="bg-white w-full max-w-[720px] min-h-[1020px] h-full px-[80px] pt-[92px] pb-[120px] flex flex-col">
             {/* 결제 란 */}

--- a/wise-office-client/src/components/document/MinuteDocument.tsx
+++ b/wise-office-client/src/components/document/MinuteDocument.tsx
@@ -6,12 +6,10 @@ import { ReadableCell } from "./ReadableCell";
 export default function MinuteDocument() {
     const { minutesInfo } = usePreviewStore();
 
-    console.log("000", minutesInfo);
-
     if (!minutesInfo) return null;
 
     return (
-        <div className="bg-white w-[720px] by-whiteitems-center p-12">
+        <div className="bg-white w-full max-w-[720px] min-h-[1020px] h-full px-[80px] pt-[92px] pb-[120px] flex flex-col">
             {/* 결제 란 */}
             <ApprovalSeal />
 
@@ -19,7 +17,9 @@ export default function MinuteDocument() {
             <div className="text-center font-serif font-bold text-2xl tracking-[12px] mb-1 text-black">
                 회 의 록
             </div>
+
             <div className="w-3/5 mx-auto h-1 bg-gradient-to-r from-black via-white to-black mb-6" />
+
             {/* 상세사항 */}
             <table className="w-full border-collapse">
                 <colgroup>
@@ -42,14 +42,21 @@ export default function MinuteDocument() {
 
                 <tbody>
                     <tr>
-                        <LabelCell label="회의 날짜" />
-                        <ReadableCell
-                            colSpan={1}
-                            value={minutesInfo.minutesDate}
-                        />
+                        <LabelCell label="회의 일시" />
                         <ReadableCell
                             colSpan={2}
-                            value={`${minutesInfo.startTime}~${minutesInfo.endTime}`}
+                            value={new Date(
+                                minutesInfo.minutesDate,
+                            ).toLocaleDateString("ko-KR", {
+                                year: "numeric",
+                                month: "long",
+                                day: "numeric",
+                                weekday: "long",
+                            })}
+                        />
+                        <ReadableCell
+                            colSpan={1}
+                            value={`${minutesInfo.startTime} ~ ${minutesInfo.endTime}`}
                         />
                     </tr>
                     <tr>
@@ -63,16 +70,21 @@ export default function MinuteDocument() {
                         <LabelCell label="회의 목적" />
                         <ReadableCell colSpan={3} value={minutesInfo.purpose} />
                     </tr>
-                    <tr>
+                    <tr style={{ height: "120px" }}>
                         <LabelCell label="참 석 자" />
                         <ReadableCell
                             colSpan={3}
                             value={minutesInfo.minutesAttendants}
+                            style={"text-start"}
                         />
                     </tr>
                     <tr>
                         <LabelCell label="작 성 자" />
-                        <ReadableCell colSpan={3} value={minutesInfo.writer} />
+                        <ReadableCell
+                            colSpan={3}
+                            value={minutesInfo.writer}
+                            style={"text-start"}
+                        />
                     </tr>
                     <tr className="h-4"></tr>
                 </tbody>
@@ -84,7 +96,7 @@ export default function MinuteDocument() {
             <textarea
                 value={minutesInfo.meetingContent}
                 className="w-full border border-t-0 border-black p-4 text-sm leading-relaxed 
-                        text-slate-800 resize-none overflow-hidden focus:outline-none rounded-b min-h-[340px]"
+                        text-slate-800 resize-none overflow-hidden focus:outline-none rounded-b flex-1"
             />
         </div>
     );

--- a/wise-office-client/src/components/document/MinutePreview.tsx
+++ b/wise-office-client/src/components/document/MinutePreview.tsx
@@ -1,0 +1,90 @@
+import { LabelCell } from "./LabelCell";
+import ApprovalSeal from "./ApprovalSeal";
+import { usePreviewStore } from "@/store/useOverviewStore";
+import { ReadableCell } from "./ReadableCell";
+
+export default function MinutePreview() {
+    const { minutesInfo } = usePreviewStore();
+
+    if (!minutesInfo) return null;
+
+    return (
+        <div className="bg-white w-[720px] by-whiteitems-center p-12">
+            {/* 결제 란 */}
+            <ApprovalSeal />
+
+            {/* 제목 */}
+            <div className="text-center font-serif font-bold text-2xl tracking-[12px] mb-1 text-black">
+                회 의 록
+            </div>
+            <div className="w-3/5 mx-auto h-1 bg-gradient-to-r from-black via-white to-black mb-6" />
+            {/* 상세사항 */}
+            <table className="w-full border-collapse">
+                <colgroup>
+                    <col style={{ width: "25%" }} />
+                    <col style={{ width: "25%" }} />
+                    <col style={{ width: "25%" }} />
+                    <col style={{ width: "25%" }} />
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <LabelCell label="과제명" />
+                        <ReadableCell colSpan={3} value={minutesInfo.title} />
+                    </tr>
+                    <tr>
+                        <LabelCell label="회의주관기관" />
+                        <ReadableCell colSpan={3} value={minutesInfo.host} />
+                    </tr>
+                    <tr className="h-4"></tr>
+                </tbody>
+
+                <tbody>
+                    <tr>
+                        <LabelCell label="회의 날짜" />
+                        <ReadableCell
+                            colSpan={1}
+                            value={minutesInfo.minutesDate}
+                        />
+                        <ReadableCell
+                            colSpan={2}
+                            value={`${minutesInfo.startTime}~${minutesInfo.endTime}`}
+                        />
+                    </tr>
+                    <tr>
+                        <LabelCell label="회의 장소" />
+                        <ReadableCell
+                            colSpan={3}
+                            value={minutesInfo.location}
+                        />
+                    </tr>
+                    <tr>
+                        <LabelCell label="회의 목적" />
+                        <ReadableCell colSpan={3} value={minutesInfo.purpose} />
+                    </tr>
+                    <tr>
+                        <LabelCell label="참 석 자" />
+                        <ReadableCell
+                            colSpan={3}
+                            value={minutesInfo.minutesAttendants}
+                        />
+                    </tr>
+                    <tr>
+                        <LabelCell label="작 성 자" />
+                        <ReadableCell colSpan={3} value={minutesInfo.writer} />
+                    </tr>
+                    <tr className="h-4"></tr>
+                </tbody>
+            </table>
+
+            <div className="text-center font-semibold py-2 border border-black text-sm text-black tracking-widest bg-gray-300">
+                회 의 내 용
+            </div>
+            <textarea
+                value={minutesInfo.meetingContent}
+                className="w-full border border-t-0 border-black p-4 text-sm leading-relaxed 
+                        text-slate-800 resize-none overflow-hidden focus:outline-none rounded-b min-h-[340px]"
+            />
+            {/* <ReadableCell colSpan={1} value={minutesInfo.meetingContent} /> */}
+        </div>
+    );
+}

--- a/wise-office-client/src/components/document/MinutePreview.tsx
+++ b/wise-office-client/src/components/document/MinutePreview.tsx
@@ -84,7 +84,6 @@ export default function MinutePreview() {
                 className="w-full border border-t-0 border-black p-4 text-sm leading-relaxed 
                         text-slate-800 resize-none overflow-hidden focus:outline-none rounded-b min-h-[340px]"
             />
-            {/* <ReadableCell colSpan={1} value={minutesInfo.meetingContent} /> */}
         </div>
     );
 }

--- a/wise-office-client/src/components/document/ReadableCell.tsx
+++ b/wise-office-client/src/components/document/ReadableCell.tsx
@@ -1,0 +1,18 @@
+interface ReadableCellProps {
+    colSpan: number;
+    value: string;
+}
+
+export function ReadableCell({ colSpan = 1, value }: ReadableCellProps) {
+    return (
+        <td colSpan={colSpan} className={`border border-black p-2`}>
+            <div className="flex items-center w-full">
+                <textarea
+                    value={value}
+                    rows={1}
+                    className={`w-full resize-none bg-transparent font-medium focus:outline-none leading-snug py-2`}
+                />
+            </div>
+        </td>
+    );
+}

--- a/wise-office-client/src/components/document/ReadableCell.tsx
+++ b/wise-office-client/src/components/document/ReadableCell.tsx
@@ -1,14 +1,18 @@
 interface ReadableCellProps {
     colSpan: number;
     value: string;
-    style?: string;
+    textAlign?: string;
 }
 
-export function ReadableCell({ colSpan = 1, value, style }: ReadableCellProps) {
+export function ReadableCell({
+    colSpan = 1,
+    value,
+    textAlign,
+}: ReadableCellProps) {
     return (
         <td
             colSpan={colSpan}
-            className={`border border-black px-2 ${style ? "text-start" : "text-center"}`}
+            className={`border border-black px-2 ${textAlign ? "text-start" : "text-center"}`}
         >
             <p className="font-normal leading-snug">{value}</p>
         </td>

--- a/wise-office-client/src/components/document/ReadableCell.tsx
+++ b/wise-office-client/src/components/document/ReadableCell.tsx
@@ -1,18 +1,16 @@
 interface ReadableCellProps {
     colSpan: number;
     value: string;
+    style?: string;
 }
 
-export function ReadableCell({ colSpan = 1, value }: ReadableCellProps) {
+export function ReadableCell({ colSpan = 1, value, style }: ReadableCellProps) {
     return (
-        <td colSpan={colSpan} className={`border border-black p-2`}>
-            <div className="flex items-center w-full">
-                <textarea
-                    value={value}
-                    rows={1}
-                    className={`w-full resize-none bg-transparent font-medium focus:outline-none leading-snug py-2`}
-                />
-            </div>
+        <td
+            colSpan={colSpan}
+            className={`border border-black px-2 ${style ? "text-start" : "text-center"}`}
+        >
+            <p className="font-normal leading-snug">{value}</p>
         </td>
     );
 }

--- a/wise-office-client/src/components/header/Toolbar.tsx
+++ b/wise-office-client/src/components/header/Toolbar.tsx
@@ -4,7 +4,7 @@ import { Calculator, File, LayoutListIcon } from "lucide-react";
 
 const toolbarLinks = [
     { href: "/", Icon: LayoutListIcon, label: "프로젝트 현황" },
-    { href: "/overview", Icon: File, label: "전체 품의서" },
+    { href: "/overview", Icon: File, label: "문서 현황" },
     { href: "/leave-calculator", Icon: Calculator, label: "연차계산기" },
 ];
 

--- a/wise-office-client/src/components/modal/PreviewModal/index.tsx
+++ b/wise-office-client/src/components/modal/PreviewModal/index.tsx
@@ -1,6 +1,6 @@
 import Buttonbar from "./Buttonbar";
 import { usePreviewStore } from "@/store/useOverviewStore";
-import MinutePreview from "@/components/document/MinutePreview";
+import MinuteDocument from "@/components/document/MinuteDocument";
 import { useEffect } from "react";
 
 const A4_WIDTH = 720;
@@ -28,7 +28,7 @@ export default function PreviewModal() {
             />
 
             <div className="print-area">
-                <MinutePreview />
+                <MinuteDocument />
             </div>
 
             <Buttonbar

--- a/wise-office-client/src/components/modal/PreviewModal/index.tsx
+++ b/wise-office-client/src/components/modal/PreviewModal/index.tsx
@@ -1,66 +1,41 @@
-import { useEffect, useState } from "react";
 import Buttonbar from "./Buttonbar";
 import { usePreviewStore } from "@/store/useOverviewStore";
+import MinutePreview from "@/components/document/MinutePreview";
+import { useEffect } from "react";
 
-const A4_WIDTH = 595;
-const A4_HEIGHT = Math.round(595 * Math.SQRT2);
-const A4_PADDING = 71;
-const MODAL_PADDING = 32;
-const HEADER_FOOTER_HEIGHT = 64;
+const A4_WIDTH = 720;
+const A4_HEIGHT = 1020;
 
 export default function PreviewModal() {
     const { onClose } = usePreviewStore();
-    const [scale, setScale] = useState(1);
 
     useEffect(() => {
-        const calculateScale = () => {
-            const maxWidth = window.innerWidth - MODAL_PADDING * 2;
-            const maxHeight =
-                window.innerHeight - HEADER_FOOTER_HEIGHT - MODAL_PADDING * 2;
+        const original = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
 
-            const scaleByWidth = maxWidth / 595;
-            const scaleByHeight = maxHeight / Math.round(595 * Math.SQRT2);
-
-            // 너비/높이 중 더 작은 쪽 기준으로 맞춤
-            setScale(Math.min(scaleByWidth, scaleByHeight, 1)); //최댓값 지정하여 원본을 초과하지 않도록 함
+        return () => {
+            document.body.style.overflow = original;
         };
-
-        calculateScale();
-        window.addEventListener("resize", calculateScale);
-        return () => window.removeEventListener("resize", calculateScale);
     }, []);
 
     return (
-        <div
-            onClick={onClose}
-            className="fixed inset-0 bg-black/50 flex flex-col items-center justify-center z-1000"
-        >
-            <div onClick={(e) => e.stopPropagation()}>
-                <Buttonbar
-                    key="buttonbar-top"
-                    position="top"
-                    modalWidth={A4_WIDTH * scale}
-                    onClose={onClose}
-                />
+        <div>
+            <Buttonbar
+                key="buttonbar-top"
+                position="top"
+                modalWidth={A4_WIDTH}
+                onClose={onClose}
+            />
 
-                {/* A4 용지 */}
-                <div
-                    style={{
-                        width: A4_WIDTH * scale,
-                        height: A4_HEIGHT * scale,
-                        padding: A4_PADDING * scale,
-                    }}
-                    className="relative bg-white overflow-hidden"
-                >
-                    <div className="print-area">{/* 회의록/품의서 내용 */}</div>
-                </div>
-
-                <Buttonbar
-                    key="buttonbar-bottom"
-                    position="bottom"
-                    modalWidth={A4_WIDTH * scale}
-                />
+            <div className="print-area">
+                <MinutePreview />
             </div>
+
+            <Buttonbar
+                key="buttonbar-bottom"
+                position="bottom"
+                modalWidth={A4_WIDTH}
+            />
         </div>
     );
 }

--- a/wise-office-client/src/components/modal/PreviewModal/index.tsx
+++ b/wise-office-client/src/components/modal/PreviewModal/index.tsx
@@ -4,7 +4,6 @@ import MinuteDocument from "@/components/document/MinuteDocument";
 import { useEffect } from "react";
 
 const A4_WIDTH = 720;
-const A4_HEIGHT = 1020;
 
 export default function PreviewModal() {
     const { onClose } = usePreviewStore();

--- a/wise-office-client/src/components/modal/PreviewModal/index.tsx
+++ b/wise-office-client/src/components/modal/PreviewModal/index.tsx
@@ -27,9 +27,7 @@ export default function PreviewModal() {
                 onClose={onClose}
             />
 
-            <div className="print-area">
-                <MinuteDocument />
-            </div>
+            <MinuteDocument />
 
             <Buttonbar
                 key="buttonbar-bottom"

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -31,11 +31,19 @@ export default function MonthOverviewList() {
                     >
                         <OverviewCard
                             key={`${minutes.minutes_pk}-minutes`}
-                            minutes={minutes}
+                            minutes={{
+                                minutesId: minutes.minutes_pk,
+                                title: minutes.title,
+                                minutesAt: minutes.minutes_date.toISOString(),
+                            }}
                         />
                         <OverviewCard
                             key={`${minutes.minutes_pk}-approval`}
-                            minutes={minutes}
+                            minutes={{
+                                minutesId: minutes.minutes_pk,
+                                title: minutes.title,
+                                minutesAt: minutes.minutes_date.toISOString(),
+                            }}
                             isApproval={true}
                         />
                     </div>

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -58,7 +58,7 @@ export default function OverviewCard({ minutes, isApproval }: Props) {
             {/* 버튼 */}
             <div className="flex justify-between gap-2">
                 <PreviewButton minutesInfo={minutesInfo} />
-                <PrintButton />
+                <PrintButton minutesInfo={minutesInfo} />
             </div>
         </div>
     );

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -1,17 +1,34 @@
-import { Minutes } from "@/types/document";
+import { useEffect, useState } from "react";
 import PreviewButton from "@/components/ui/button/PreviewButton";
 import PrintButton from "@/components/ui/button/PrintButton";
-import { APPROVALS } from "@/lib/data/overview";
+import { getMinutesInfo } from "@/services/overview";
+import { useOverviewStore } from "@/store/useOverviewStore";
+import { MinutesInfo, MinutesItem } from "@/types/document";
 
 interface Props {
-    minutes?: Minutes;
+    minutes: MinutesItem;
     isApproval?: boolean;
 }
 
 export default function OverviewCard({ minutes, isApproval }: Props) {
-    const approvalMap = Object.fromEntries(
-        APPROVALS.map((a) => [a.meeting_pk, a]),
-    );
+    const { projectInfo } = useOverviewStore();
+    const [minutesInfo, setMinutesInfo] = useState<MinutesInfo>();
+
+    console.log(minutes);
+
+    useEffect(() => {
+        if (!projectInfo.projectId || !minutes?.minutesId) return;
+
+        const fetchInfo = async () => {
+            const data = await getMinutesInfo(
+                projectInfo.projectId,
+                minutes.minutesId,
+            );
+            setMinutesInfo(data);
+        };
+
+        fetchInfo();
+    }, [projectInfo.projectId, minutes?.minutesId]);
 
     return (
         <div className="flex bg-white border border-gray-300 rounded-lg px-4 py-2 items-center justify-between gap-6">
@@ -19,20 +36,24 @@ export default function OverviewCard({ minutes, isApproval }: Props) {
             <div className="flex-1 grid grid-cols-3">
                 {/* 날짜/시간 */}
                 <div className="col-span-1 flex flex-col 2xl:flex-row gap-2">
-                    <p>{minutes?.minutes_date.toLocaleDateString("sv")}</p>
                     <p>
-                        {minutes?.start_time}~{minutes?.end_time}
+                        {new Date(
+                            minutesInfo?.minutesDate ?? "",
+                        ).toLocaleDateString("sv")}
+                    </p>
+                    <p>
+                        {minutesInfo?.startTime}~{minutesInfo?.endTime}
                     </p>
                 </div>
                 {/* 문서번호 */}
                 <p className="col-span-1 flex items-center">
-                    {isApproval && minutes?.minutes_pk
-                        ? approvalMap[minutes.minutes_pk]?.report_no
-                        : minutes?.minutes_number}
+                    {isApproval && minutes?.minutesId
+                        ? "품의서"
+                        : minutes?.title}
                 </p>
                 {/* 참석자 명단 */}
                 <p className="col-span-1 text-xs flex items-center">
-                    {minutes?.inst_attendants.join(" ")}
+                    {minutesInfo?.instAttendants}
                 </p>
             </div>
 

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -14,32 +14,33 @@ export default function OverviewCard({
     isApproval,
 }: Props) {
     return (
-        <div className="flex bg-white border border-gray-300 rounded-lg px-4 py-2 items-center justify-between gap-6">
-            {/* 날짜/시간 */}
-            <div className="col-span-1 flex flex-col 2xl:flex-row gap-2">
-                <p>{minutes.minutesAt}</p>
-                <p>
-                    {" "}
-                    {minutesInfo?.startTime}~{minutesInfo?.endTime}
-                </p>
-            </div>
-
+        <div className="flex w-full bg-white border border-gray-300 rounded-lg px-4 py-2 items-center justify-between gap-6">
             {/* 문서 정보 */}
-            <div className="flex-1 grid grid-cols-2">
-                {/* 문서번호 */}
-                <p className="col-span-1 flex items-center">
-                    {isApproval && minutes?.minutesId
-                        ? `품의서 · ${minutes?.title}`
-                        : `회의록 · ${minutes?.title}`}
-                </p>
-                {/* 참석자 명단 */}
-                <p className="col-span-1 text-xs flex items-center">
-                    {minutesInfo?.instAttendants}
-                </p>
+            <div className="flex flex-1 gap-6 items-center min-w-0">
+                {/* 날짜/시간 */}
+                <div className="flex flex-col 2xl:flex-row gap-2 shrink-0">
+                    <p>{minutes.minutesAt}</p>
+                    <p>
+                        {minutesInfo?.startTime}~{minutesInfo?.endTime}
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-2 flex-1 min-w-0 gap-6">
+                    <div className="col-span-1 flex justify-center">
+                        {/* 문서번호 */}
+                        {isApproval && minutes?.minutesId
+                            ? `품의서 · ${minutes?.title}`
+                            : `회의록 · ${minutes?.title}`}
+                    </div>
+                    {/* 참석자 명단 */}
+                    <div className="col-span-1 text-xs flex items-center">
+                        {minutesInfo?.instAttendants}
+                    </div>
+                </div>
             </div>
 
             {/* 버튼 */}
-            <div className="flex justify-between gap-2">
+            <div className="flex justify-between gap-2 shrink-0">
                 <PreviewButton minutesInfo={minutesInfo ?? null} />
                 <PrintButton minutesInfo={minutesInfo ?? null} />
             </div>

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -1,53 +1,36 @@
-import { useEffect, useState } from "react";
 import PreviewButton from "@/components/ui/button/PreviewButton";
 import PrintButton from "@/components/ui/button/PrintButton";
-import { getMinutesInfo } from "@/services/overview";
-import { useOverviewStore } from "@/store/useOverviewStore";
 import { MinutesInfo, MinutesItem } from "@/types/document";
 
 interface Props {
     minutes: MinutesItem;
+    minutesInfo?: MinutesInfo;
     isApproval?: boolean;
 }
 
-export default function OverviewCard({ minutes, isApproval }: Props) {
-    const { projectInfo } = useOverviewStore();
-    const [minutesInfo, setMinutesInfo] = useState<MinutesInfo | null>(null);
-
-    useEffect(() => {
-        if (!projectInfo.projectId || !minutes?.minutesId) return;
-
-        const fetchInfo = async () => {
-            const data = await getMinutesInfo(
-                projectInfo.projectId,
-                minutes.minutesId,
-            );
-            setMinutesInfo(data);
-        };
-
-        fetchInfo();
-    }, [projectInfo.projectId, minutes?.minutesId]);
-
+export default function OverviewCard({
+    minutes,
+    minutesInfo,
+    isApproval,
+}: Props) {
     return (
         <div className="flex bg-white border border-gray-300 rounded-lg px-4 py-2 items-center justify-between gap-6">
+            {/* 날짜/시간 */}
+            <div className="col-span-1 flex flex-col 2xl:flex-row gap-2">
+                <p>{minutes.minutesAt}</p>
+                <p>
+                    {" "}
+                    {minutesInfo?.startTime}~{minutesInfo?.endTime}
+                </p>
+            </div>
+
             {/* 문서 정보 */}
-            <div className="flex-1 grid grid-cols-3">
-                {/* 날짜/시간 */}
-                <div className="col-span-1 flex flex-col 2xl:flex-row gap-2">
-                    <p>
-                        {new Date(
-                            minutesInfo?.minutesDate ?? "",
-                        ).toLocaleDateString("sv")}
-                    </p>
-                    <p>
-                        {minutesInfo?.startTime}~{minutesInfo?.endTime}
-                    </p>
-                </div>
+            <div className="flex-1 grid grid-cols-2">
                 {/* 문서번호 */}
                 <p className="col-span-1 flex items-center">
                     {isApproval && minutes?.minutesId
-                        ? "품의서"
-                        : minutes?.title}
+                        ? `품의서 · ${minutes?.title}`
+                        : `회의록 · ${minutes?.title}`}
                 </p>
                 {/* 참석자 명단 */}
                 <p className="col-span-1 text-xs flex items-center">
@@ -57,8 +40,8 @@ export default function OverviewCard({ minutes, isApproval }: Props) {
 
             {/* 버튼 */}
             <div className="flex justify-between gap-2">
-                <PreviewButton minutesInfo={minutesInfo} />
-                <PrintButton minutesInfo={minutesInfo} />
+                <PreviewButton minutesInfo={minutesInfo ?? null} />
+                <PrintButton minutesInfo={minutesInfo ?? null} />
             </div>
         </div>
     );

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -12,9 +12,7 @@ interface Props {
 
 export default function OverviewCard({ minutes, isApproval }: Props) {
     const { projectInfo } = useOverviewStore();
-    const [minutesInfo, setMinutesInfo] = useState<MinutesInfo>();
-
-    console.log(minutes);
+    const [minutesInfo, setMinutesInfo] = useState<MinutesInfo | null>(null);
 
     useEffect(() => {
         if (!projectInfo.projectId || !minutes?.minutesId) return;
@@ -59,7 +57,7 @@ export default function OverviewCard({ minutes, isApproval }: Props) {
 
             {/* 버튼 */}
             <div className="flex justify-between gap-2">
-                <PreviewButton />
+                <PreviewButton minutesInfo={minutesInfo} />
                 <PrintButton />
             </div>
         </div>

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -26,7 +26,7 @@ export default function OverviewCard({
                 </div>
 
                 <div className="grid grid-cols-2 flex-1 min-w-0 gap-6">
-                    <div className="col-span-1 flex justify-center">
+                    <div className="col-span-1 flex justify-center items-center">
                         {/* 문서번호 */}
                         {isApproval && minutes?.minutesId
                             ? `품의서 · ${minutes?.title}`

--- a/wise-office-client/src/components/overview/ProjectMenu.tsx
+++ b/wise-office-client/src/components/overview/ProjectMenu.tsx
@@ -59,7 +59,7 @@ export default function ProjectMenu() {
 
                         {openYear.includes(menu.year) && (
                             <ul className="ml-10 cursor-pointer">
-                                {menu.projects.slice().map((item) => (
+                                {menu.projects.map((item) => (
                                     <li
                                         key={item.projectId}
                                         className={`px-3 py-1 mb-1 text-sm rounded-md hover:bg-gray-100 hover:font-medium ${item.projectId === projectInfo.projectId && menu.year === year ? "bg-gray-100 font-medium" : ""}`}

--- a/wise-office-client/src/components/overview/ProjectMenu.tsx
+++ b/wise-office-client/src/components/overview/ProjectMenu.tsx
@@ -34,8 +34,6 @@ export default function ProjectMenu() {
         [groupByYear],
     );
 
-    console.log(groupByYear);
-
     return (
         <aside className="w-72">
             <ul>

--- a/wise-office-client/src/components/overview/ProjectMenu.tsx
+++ b/wise-office-client/src/components/overview/ProjectMenu.tsx
@@ -6,9 +6,8 @@ import {
 } from "@/store/useOverviewStore";
 
 export default function ProjectMenu() {
-    const { year, projectId, setYear, setProjectId } = useOverviewStore();
+    const { year, projectInfo, setYear, setProjectInfo } = useOverviewStore();
     const { groupByYear, fetchGroupByYear } = useProjectsGroupByYearStore();
-
     const [openYear, setOpenYear] = useState<number[]>([]);
 
     useEffect(() => {
@@ -35,6 +34,8 @@ export default function ProjectMenu() {
         [groupByYear],
     );
 
+    console.log(groupByYear);
+
     return (
         <aside className="w-72">
             <ul>
@@ -60,12 +61,15 @@ export default function ProjectMenu() {
 
                         {openYear.includes(menu.year) && (
                             <ul className="ml-10 cursor-pointer">
-                                {menu.projects.map((item) => (
+                                {menu.projects.slice().map((item) => (
                                     <li
                                         key={item.projectId}
-                                        className={`px-3 py-1 mb-1 text-sm rounded-md hover:bg-gray-100 hover:font-medium ${item.projectId === projectId && menu.year === year ? "bg-gray-100 font-medium" : ""}`}
+                                        className={`px-3 py-1 mb-1 text-sm rounded-md hover:bg-gray-100 hover:font-medium ${item.projectId === projectInfo.projectId && menu.year === year ? "bg-gray-100 font-medium" : ""}`}
                                         onClick={() => {
-                                            setProjectId(item.projectId);
+                                            setProjectInfo({
+                                                projectId: item.projectId,
+                                                projectTitle: item.projectTitle,
+                                            });
                                             setYear(menu.year);
                                         }}
                                     >

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -1,20 +1,31 @@
 import { useEffect, useState } from "react";
 import OverviewCard from "./OverviewCard";
 import { useOverviewStore } from "@/store/useOverviewStore";
-import { getMinutes } from "@/services/overview";
-import { MinutesList } from "@/types/document";
+import { getMinutes, getMinutesInfo } from "@/services/overview";
+import { MinutesInfo, MinutesList } from "@/types/document";
 
 export default function ProjectOverviewList() {
     const { year, projectInfo } = useOverviewStore();
-    const [minutesList, setMinutesList] = useState<MinutesList>();
+    const [minutesList, setMinutesList] = useState<MinutesList>([]);
+    const [minutesInfos, setMinutesInfos] = useState<MinutesInfo[]>([]);
 
     useEffect(() => {
         const fetchMinutes = async () => {
             const data = await getMinutes(projectInfo.projectId);
             setMinutesList(data);
+
+            const infos = await Promise.all(
+                data.map((m) =>
+                    getMinutesInfo(projectInfo.projectId, m.minutesId),
+                ),
+            );
+
+            setMinutesInfos(infos);
         };
 
-        fetchMinutes();
+        if (projectInfo.projectId) {
+            fetchMinutes();
+        }
     }, [projectInfo.projectId]);
 
     const filteredData =
@@ -35,6 +46,10 @@ export default function ProjectOverviewList() {
         };
     }).filter((m) => m.data.length > 0);
 
+    if (!minutesList.length || !minutesInfos.length) {
+        return null;
+    }
+
     return (
         <div className="flex flex-col gap-10">
             <p className="text-2xl font-bold">{projectInfo.projectTitle}</p>
@@ -45,26 +60,32 @@ export default function ProjectOverviewList() {
                     <div key={month} className="flex flex-col gap-4 pr-16">
                         <p className="text-lg font-semibold">{month}월</p>
 
-                        {data.map((minutes, index) => (
-                            <div
-                                key={minutes.minutesId}
-                                className={`flex flex-col gap-3 ${
-                                    index !== data.length - 1
-                                        ? "pb-4 border-b border-gray-200"
-                                        : ""
-                                }`}
-                            >
-                                <OverviewCard
-                                    key={`${minutes.minutesId}-minutes`}
-                                    minutes={minutes}
-                                />
-                                <OverviewCard
-                                    key={`${minutes.minutesId}-approval`}
-                                    minutes={minutes}
-                                    isApproval={true}
-                                />
-                            </div>
-                        ))}
+                        {data.map((minutes, index) => {
+                            const minutesInfo = minutesInfos.find(
+                                (info) => info.minutesId === minutes.minutesId,
+                            );
+
+                            return (
+                                <div
+                                    key={minutes.minutesId}
+                                    className={`flex flex-col gap-3 ${
+                                        index !== data.length - 1
+                                            ? "pb-4 border-b border-gray-200"
+                                            : ""
+                                    }`}
+                                >
+                                    <OverviewCard
+                                        minutes={minutes}
+                                        minutesInfo={minutesInfo}
+                                    />
+                                    <OverviewCard
+                                        minutes={minutes}
+                                        minutesInfo={minutesInfo}
+                                        isApproval={true}
+                                    />
+                                </div>
+                            );
+                        })}
                     </div>
                 ))}
         </div>

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -1,33 +1,43 @@
-import { useOverviewStore } from "@/store/useOverviewStore";
+import { useEffect, useState } from "react";
 import OverviewCard from "./OverviewCard";
-import { MINUTES, projectNames } from "@/lib/data/overview";
+import { useOverviewStore } from "@/store/useOverviewStore";
+import { getMinutes } from "@/services/overview";
+import { MinutesList } from "@/types/document";
 
 export default function ProjectOverviewList() {
-    const { year, projectId } = useOverviewStore();
+    const { year, projectInfo } = useOverviewStore();
+    const [minutesList, setMinutesList] = useState<MinutesList>();
 
-    const projectName = projectNames.find(
-        (m) => m.project_pk === projectId,
-    )?.title;
+    useEffect(() => {
+        const fetchMinutes = async () => {
+            const data = await getMinutes(projectInfo.projectId);
+            setMinutesList(data);
+        };
 
-    const filteredData = MINUTES.filter(
-        (m) =>
-            m.project_pk === projectId && m.minutes_date.getFullYear() === year,
-    );
+        fetchMinutes();
+    }, [projectInfo.projectId]);
+
+    const filteredData =
+        minutesList?.filter(
+            (m) => new Date(m.minutesAt).getFullYear() === year,
+        ) ?? [];
 
     const groupedByMonth = Array.from({ length: 12 }, (_, i) => {
-        const month = i + 1;
+        const month = i;
+
+        const data = filteredData.filter(
+            (m) => new Date(m.minutesAt).getMonth() === month,
+        );
 
         return {
-            month,
-            data: filteredData.filter(
-                (m) => m.minutes_date.getMonth() + 1 === month,
-            ),
+            month: month + 1,
+            data,
         };
     }).filter((m) => m.data.length > 0);
 
     return (
         <div className="flex flex-col gap-10">
-            <p className="text-2xl font-bold">{projectName}</p>
+            <p className="text-2xl font-bold">{projectInfo.projectTitle}</p>
 
             {groupedByMonth
                 .sort((a, b) => a.month - b.month)
@@ -37,7 +47,7 @@ export default function ProjectOverviewList() {
 
                         {data.map((minutes, index) => (
                             <div
-                                key={minutes.minutes_pk}
+                                key={minutes.minutesId}
                                 className={`flex flex-col gap-3 ${
                                     index !== data.length - 1
                                         ? "pb-4 border-b border-gray-200"
@@ -45,11 +55,11 @@ export default function ProjectOverviewList() {
                                 }`}
                             >
                                 <OverviewCard
-                                    key={`${minutes.minutes_pk}-minutes`}
+                                    key={`${minutes.minutesId}-minutes`}
                                     minutes={minutes}
                                 />
                                 <OverviewCard
-                                    key={`${minutes.minutes_pk}-approval`}
+                                    key={`${minutes.minutesId}-approval`}
                                     minutes={minutes}
                                     isApproval={true}
                                 />

--- a/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
+++ b/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
@@ -34,7 +34,7 @@ export default function MinutePreview({
                 title: projectTitle,
             });
         }
-    }, [minuteDetail]);
+    }, [minuteDetail, projectTitle, setMinutesInfo]);
 
     if (!minuteDetail) {
         return <BasePreview type="minute" />;

--- a/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
+++ b/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
@@ -32,7 +32,6 @@ export default function MinutePreview({
             setMinutesInfo({
                 ...minuteDetail,
                 title: projectTitle,
-                content: minuteDetail.meetingContent,
             });
         }
     }, [minuteDetail, projectTitle, setMinutesInfo]);

--- a/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
+++ b/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
@@ -82,7 +82,9 @@ export default function MinutePreview({
                     </div>
                 )}
 
-                <MinuteDocument />
+                <div className="print-area flex justify-center ">
+                    <MinuteDocument />
+                </div>
             </div>
         </div>
     );

--- a/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
+++ b/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
@@ -32,6 +32,7 @@ export default function MinutePreview({
             setMinutesInfo({
                 ...minuteDetail,
                 title: projectTitle,
+                content: minuteDetail.meetingContent,
             });
         }
     }, [minuteDetail, projectTitle, setMinutesInfo]);

--- a/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
+++ b/wise-office-client/src/components/project/document/preview/MinutePreview.tsx
@@ -3,9 +3,13 @@ import BasePreview from "./BasePreview";
 import Button from "@/components/common/Button";
 import { DeleteModalState } from "@/types/project";
 import { useApproveCreation } from "@/hooks/project/useDocuments";
+import MinuteDocument from "@/components/document/MinuteDocument";
+import { usePreviewStore } from "@/store/useOverviewStore";
+import { useEffect } from "react";
 
 interface MinutePreviewProps {
     projectId: number;
+    projectTitle: string;
     minuteDetail: MinutesDetail | undefined;
     isAttending: boolean;
     onEdit: (docType: string, docId: number) => void;
@@ -14,15 +18,28 @@ interface MinutePreviewProps {
 
 export default function MinutePreview({
     projectId,
+    projectTitle,
     minuteDetail,
     isAttending,
     onEdit,
     onDelete,
 }: MinutePreviewProps) {
     const createApprove = useApproveCreation();
+    const { setMinutesInfo } = usePreviewStore();
+
+    useEffect(() => {
+        if (minuteDetail) {
+            setMinutesInfo({
+                ...minuteDetail,
+                title: projectTitle,
+            });
+        }
+    }, [minuteDetail]);
+
     if (!minuteDetail) {
         return <BasePreview type="minute" />;
     }
+
     return (
         <div className="bg-white rounded-lg shadow-sm">
             <div className="flex flex-col p-4 md:pt-6">
@@ -65,23 +82,7 @@ export default function MinutePreview({
                     </div>
                 )}
 
-                <div>
-                    <h2>회의록</h2>
-                    <div>프로젝트 ID : {projectId} </div>
-                    {/* minuteDetail 정보 */}
-                    <table>
-                        <tbody>
-                            {Object.entries(minuteDetail).map(
-                                ([key, value]) => (
-                                    <tr key={key}>
-                                        <td>{key}</td>
-                                        <td>{value}</td>
-                                    </tr>
-                                ),
-                            )}
-                        </tbody>
-                    </table>
-                </div>
+                <MinuteDocument />
             </div>
         </div>
     );

--- a/wise-office-client/src/components/ui/button/PreviewButton.tsx
+++ b/wise-office-client/src/components/ui/button/PreviewButton.tsx
@@ -1,12 +1,23 @@
 import { usePreviewStore } from "@/store/useOverviewStore";
+import { MinutesInfo } from "@/types/document";
 import { LucideFileSearch } from "lucide-react";
 
-export default function PreviewButton() {
-    const { onOpen } = usePreviewStore();
+export default function PreviewButton({
+    minutesInfo,
+}: {
+    minutesInfo: MinutesInfo | null;
+}) {
+    const { onOpen, setMinutesInfo } = usePreviewStore();
+
+    const handleClick = () => {
+        if (!minutesInfo) return;
+        setMinutesInfo(minutesInfo);
+        onOpen();
+    };
 
     return (
         <button
-            onClick={onOpen}
+            onClick={handleClick}
             className="flex border border-gray-400 rounded-md p-1 items-center bg-background-default hover:bg-gray-200 cursor-pointer"
         >
             <LucideFileSearch size={12} strokeWidth={1} />

--- a/wise-office-client/src/components/ui/button/PrintButton.tsx
+++ b/wise-office-client/src/components/ui/button/PrintButton.tsx
@@ -1,8 +1,24 @@
 import { Printer } from "lucide-react";
+import { usePreviewStore } from "@/store/useOverviewStore";
+import { MinutesInfo } from "@/types/document";
 
-export default function PrintButton() {
+type Props = {
+    minutesInfo?: MinutesInfo | null;
+};
+
+export default function PrintButton({ minutesInfo }: Props) {
+    const { setMinutesInfo } = usePreviewStore();
+
     const onPrint = () => {
-        window.print();
+        if (minutesInfo) {
+            setMinutesInfo(minutesInfo);
+
+            setTimeout(() => {
+                window.print();
+            }, 0);
+        } else {
+            window.print();
+        }
     };
 
     return (

--- a/wise-office-client/src/pages/overview/index.tsx
+++ b/wise-office-client/src/pages/overview/index.tsx
@@ -26,16 +26,21 @@ export default function Overview() {
             {isOpen && (
                 <div
                     onClick={onClose}
-                    className="fixed inset-0 bg-black/50 flex flex-col items-center justify-center z-1000 overflow-y-auto"
+                    className="fixed inset-0 bg-black/50 flex justify-center overflow-y-auto z-1000"
                 >
                     <div
                         onClick={(e) => e.stopPropagation()}
-                        className="absolute translate-y-1/3 pb-24"
+                        className="absolute translate-y-1/6 pb-24"
                     >
                         <PreviewModal />
                     </div>
                 </div>
             )}
+
+            {/* print용 DOM (항상 존재하지만 화면에서는 숨김) */}
+            <div className="hidden print:block">
+                <PreviewModal />
+            </div>
         </div>
     );
 }

--- a/wise-office-client/src/pages/overview/index.tsx
+++ b/wise-office-client/src/pages/overview/index.tsx
@@ -8,7 +8,7 @@ import { useOverviewStore, usePreviewStore } from "@/store/useOverviewStore";
 
 export default function Overview() {
     const { optionIndex, projectInfo } = useOverviewStore();
-    const { isOpen } = usePreviewStore();
+    const { isOpen, onClose } = usePreviewStore();
 
     return (
         <div className="min-h-screen flex mx-24 my-16 gap-16">
@@ -23,7 +23,19 @@ export default function Overview() {
                     <MonthOverviewList />
                 )}
             </div>
-            {isOpen && <PreviewModal />}
+            {isOpen && (
+                <div
+                    onClick={onClose}
+                    className="fixed inset-0 bg-black/50 flex flex-col items-center justify-center z-1000 overflow-y-auto"
+                >
+                    <div
+                        onClick={(e) => e.stopPropagation()}
+                        className="absolute translate-y-1/3 pb-24"
+                    >
+                        <PreviewModal />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/wise-office-client/src/pages/overview/index.tsx
+++ b/wise-office-client/src/pages/overview/index.tsx
@@ -7,7 +7,7 @@ import PreviewModal from "@/components/modal/PreviewModal";
 import { useOverviewStore, usePreviewStore } from "@/store/useOverviewStore";
 
 export default function Overview() {
-    const { optionIndex } = useOverviewStore();
+    const { optionIndex, projectInfo } = useOverviewStore();
     const { isOpen } = usePreviewStore();
 
     return (
@@ -18,7 +18,7 @@ export default function Overview() {
             </div>
             <div className="flex-1">
                 {optionIndex === 0 ? (
-                    <ProjectOverviewList />
+                    <ProjectOverviewList key={projectInfo.projectId} />
                 ) : (
                     <MonthOverviewList />
                 )}

--- a/wise-office-client/src/pages/overview/index.tsx
+++ b/wise-office-client/src/pages/overview/index.tsx
@@ -5,6 +5,7 @@ import ProjectOverviewList from "@/components/overview/ProjectOverviewList";
 import MonthOverviewList from "@/components/overview/MonthOverviewList";
 import PreviewModal from "@/components/modal/PreviewModal";
 import { useOverviewStore, usePreviewStore } from "@/store/useOverviewStore";
+import MinuteDocument from "@/components/document/MinuteDocument";
 
 export default function Overview() {
     const { optionIndex, projectInfo } = useOverviewStore();
@@ -23,6 +24,7 @@ export default function Overview() {
                     <MonthOverviewList />
                 )}
             </div>
+
             {isOpen && (
                 <div
                     onClick={onClose}
@@ -37,9 +39,9 @@ export default function Overview() {
                 </div>
             )}
 
-            {/* print용 DOM (항상 존재하지만 화면에서는 숨김) */}
-            <div className="hidden print:block">
-                <PreviewModal />
+            {/* 프린트 전용 - 화면에서는 숨김, 항상 DOM에 존재 */}
+            <div className="print-area hidden print:block">
+                <MinuteDocument />
             </div>
         </div>
     );

--- a/wise-office-client/src/pages/projects/[projectId]/documents/[docType]/[docId].tsx
+++ b/wise-office-client/src/pages/projects/[projectId]/documents/[docType]/[docId].tsx
@@ -130,7 +130,7 @@ export default function DocumentPage() {
                 minutesAttendants,
                 instAttendants,
                 writer,
-                meetingContent,
+                content,
             } = minuteDetail;
 
             setForm({
@@ -143,7 +143,7 @@ export default function DocumentPage() {
                 minutesAttendants,
                 instAttendants,
                 writer,
-                content: meetingContent, // 필드명 불일치, 서버 dto 수정 예정
+                content, // 필드명 불일치, 서버 dto 수정 예정
             });
 
             setSavedTime("MM/DD HH:MM");

--- a/wise-office-client/src/pages/projects/[projectId]/index.tsx
+++ b/wise-office-client/src/pages/projects/[projectId]/index.tsx
@@ -168,6 +168,7 @@ export default function ProjectById() {
                                 return (
                                     <MinutePreview
                                         projectId={projectId}
+                                        projectTitle={projectInfo.projectTitle}
                                         minuteDetail={minute}
                                         isAttending={projectInfo.attending}
                                         onEdit={openDocumentEditor}

--- a/wise-office-client/src/services/overview.ts
+++ b/wise-office-client/src/services/overview.ts
@@ -14,5 +14,5 @@ export async function getMinutesInfo(
         `/projects/${projectId}/minutes/${minutesId}`,
     );
 
-    return data ?? [];
+    return data;
 }

--- a/wise-office-client/src/services/overview.ts
+++ b/wise-office-client/src/services/overview.ts
@@ -1,0 +1,18 @@
+import { api } from "@/lib/clientApi";
+import { MinutesInfo, MinutesList } from "@/types/document";
+
+export async function getMinutes(projectId: number): Promise<MinutesList> {
+    const { data } = await api.get(`/projects/${projectId}/minutes`);
+    return data;
+}
+
+export async function getMinutesInfo(
+    projectId: number,
+    minutesId: number,
+): Promise<MinutesInfo> {
+    const { data } = await api.get(
+        `/projects/${projectId}/minutes/${minutesId}`,
+    );
+
+    return data ?? [];
+}

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -1,36 +1,34 @@
 import { create } from "zustand";
-import { MINUTES } from "@/lib/data/overview";
 import { ProjectGroupByYear } from "@/types/project";
 import { getProjectsGroupByYear } from "@/services/projects";
 
-const today = new Date();
+type ProjectInfo = {
+    projectId: number;
+    projectTitle: string;
+};
 
 type OverviewState = {
     optionIndex: number;
     year: number;
     month: number;
-    projectId: number;
+    projectInfo: ProjectInfo;
 
     setOptionIndex: (optionIndex: number) => void;
     setYear: (year: number) => void;
     setMonth: (month: number) => void;
-    setProjectId: (projectId: number) => void;
+    setProjectInfo: (projectInfo: ProjectInfo) => void;
 };
 
 export const useOverviewStore = create<OverviewState>((set) => ({
     optionIndex: 0,
-    year:
-        MINUTES.length > 0
-            ? Math.max(...MINUTES.map((m) => m.minutes_date.getFullYear()))
-            : today.getFullYear(),
-    month: today.getMonth(),
-    projectId:
-        MINUTES.length > 0 ? Math.min(...MINUTES.map((m) => m.project_pk)) : 0,
+    year: new Date().getFullYear(),
+    month: new Date().getMonth(),
+    projectInfo: { projectId: 0, projectTitle: "" },
 
     setOptionIndex: (optionIndex) => set({ optionIndex }),
     setYear: (year) => set({ year }),
     setMonth: (month) => set({ month }),
-    setProjectId: (projectId) => set({ projectId }),
+    setProjectInfo: (projectInfo: ProjectInfo) => set({ projectInfo }),
 }));
 
 // 연도별 프로젝트 메뉴
@@ -45,13 +43,33 @@ export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
 
         fetchGroupByYear: async () => {
             const data = await getProjectsGroupByYear();
+            const currentYear = new Date().getFullYear();
 
-            set({
-                groupByYear: Array.isArray(data)
-                    ? data.filter(
-                          (item) => item.year <= new Date().getFullYear(),
-                      )
-                    : [],
+            const filtered = Array.isArray(data)
+                ? data.filter((item) => item.year <= currentYear)
+                : [];
+
+            set({ groupByYear: filtered });
+
+            if (filtered.length === 0) return;
+
+            const yearGroup = filtered.find(
+                (item) => item.year === currentYear,
+            );
+            if (!yearGroup || yearGroup.projects.length === 0) return;
+
+            // 해당 연도의 최소 projectId
+            const maxProjectId = Math.min(
+                ...yearGroup.projects.map((p) => p.projectId),
+            );
+
+            const currentProjectInfo = useOverviewStore.getState().projectInfo;
+            useOverviewStore.setState({
+                year: currentYear,
+                projectInfo: {
+                    ...currentProjectInfo,
+                    projectId: maxProjectId,
+                },
             });
         },
     }),

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { ProjectGroupByYear } from "@/types/project";
 import { getProjectsGroupByYear } from "@/services/projects";
+import { MinutesInfo } from "@/types/document";
 
 type ProjectInfo = {
     projectId: number;
@@ -78,7 +79,10 @@ export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
 // 미리보기 모달 상태
 type PreviewState = {
     isOpen: boolean;
+    minutesInfo: MinutesInfo | null;
+
     setIsOpen: (isOpen: boolean) => void;
+    setMinutesInfo: (minutesInfo: MinutesInfo) => void;
 
     onOpen: () => void;
     onClose: () => void;
@@ -86,7 +90,10 @@ type PreviewState = {
 
 export const usePreviewStore = create<PreviewState>((set) => ({
     isOpen: false,
+    minutesInfo: null,
+
     setIsOpen: (isOpen) => set({ isOpen }),
+    setMinutesInfo: (minutesInfo) => set({ minutesInfo }),
 
     onOpen: () => set({ isOpen: true }),
     onClose: () => set({ isOpen: false }),

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -60,16 +60,21 @@ export const useProjectsGroupByYearStore = create<ProjectGroupByYearState>(
             if (!yearGroup || yearGroup.projects.length === 0) return;
 
             // 해당 연도의 최소 projectId
-            const maxProjectId = Math.min(
+            const minProjectId = Math.min(
                 ...yearGroup.projects.map((p) => p.projectId),
             );
 
-            const currentProjectInfo = useOverviewStore.getState().projectInfo;
+            const currentProject = yearGroup.projects.find(
+                (p) => p.projectId === minProjectId,
+            );
+
+            if (!currentProject) return;
+
             useOverviewStore.setState({
                 year: currentYear,
                 projectInfo: {
-                    ...currentProjectInfo,
-                    projectId: maxProjectId,
+                    projectId: currentProject.projectId,
+                    projectTitle: currentProject.projectTitle,
                 },
             });
         },

--- a/wise-office-client/src/styles/globals.css
+++ b/wise-office-client/src/styles/globals.css
@@ -74,6 +74,11 @@ a {
         position: fixed !important;
         top: 0 !important;
         left: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        display: flex !important;
+        justify-content: center !important;
+        align-items: flex-start !important;
         margin: 0 !important;
         overflow: hidden !important;
         box-sizing: border-box !important;

--- a/wise-office-client/src/styles/globals.css
+++ b/wise-office-client/src/styles/globals.css
@@ -74,10 +74,7 @@ a {
         position: fixed !important;
         top: 0 !important;
         left: 0 !important;
-        width: 100% !important;
-        height: 100% !important;
         margin: 0 !important;
-        padding: 30mm 20mm 30mm 20mm !important; /* 상 우 하 좌 */
         overflow: hidden !important;
         box-sizing: border-box !important;
     }

--- a/wise-office-client/src/types/document.ts
+++ b/wise-office-client/src/types/document.ts
@@ -56,7 +56,7 @@ export interface MinutesDetail {
     minutesAttendants: string;
     instAttendants: string;
     writer: string;
-    meetingContent: string;
+    content: string;
 }
 
 export interface Approval {

--- a/wise-office-client/src/types/document.ts
+++ b/wise-office-client/src/types/document.ts
@@ -1,17 +1,29 @@
 export interface Minutes {
     minutes_pk: number;
     project_pk: number;
+}
+
+export interface MinutesItem {
+    minutesId: number;
+    title: string;
+    minutesAt: string;
+}
+
+export type MinutesList = MinutesItem[];
+
+export interface MinutesInfo {
+    minutesId: number;
     title: string;
     host: string;
-    minutes_date: Date;
+    minutesDate: string;
+    startTime: string;
+    endTime: string;
     location: string;
     purpose: string;
+    minutesAttendants: string;
+    instAttendants: string;
     writer: string;
-    meeting_content: string;
-    inst_attendants: string[];
-    start_time: string;
-    end_time: string;
-    minutes_number: string;
+    meetingContent: string;
 }
 
 export interface MinutesCreateRequest {

--- a/wise-office-client/src/types/document.ts
+++ b/wise-office-client/src/types/document.ts
@@ -23,7 +23,7 @@ export interface MinutesInfo {
     minutesAttendants: string;
     instAttendants: string;
     writer: string;
-    meetingContent: string;
+    content: string;
 }
 
 export interface MinutesCreateRequest {

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Project/Service/ProjectService.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Comparator;
 
 @Service
 @AllArgsConstructor
@@ -105,44 +106,45 @@ public class ProjectService {
     }
 
    @Transactional(readOnly = true)
-public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
-    final int MAX_YEAR_RANGE = 100; // 안전 범위 제한
+    public List<ProjectGroupByYearResponse> getProjectsGroupByYear() {
+        final int MAX_YEAR_RANGE = 100; // 안전 범위 제한
 
-    return projectRepository.findAllOrderByYearAndPk()
-            .stream()
-            .flatMap(project -> {
-                if (project.getStartYear() == null || project.getEndYear() == null) {
-                    return Stream.empty();
-                }
+        return projectRepository.findAllOrderByYearAndPk()
+                .stream()
+                .flatMap(project -> {
+                    if (project.getStartYear() == null || project.getEndYear() == null) {
+                        return Stream.empty();
+                    }
 
-                int start = project.getStartYear().getYear();
-                int end = project.getEndYear().getYear();
+                    int start = project.getStartYear().getYear();
+                    int end = project.getEndYear().getYear();
 
-                if (start > end) {
-                    return Stream.empty();
-                }
+                    if (start > end) {
+                        return Stream.empty();
+                    }
 
-                if (end - start > MAX_YEAR_RANGE) {
-                    end = start + MAX_YEAR_RANGE;
-                }
+                    if (end - start > MAX_YEAR_RANGE) {
+                        end = start + MAX_YEAR_RANGE;
+                    }
 
-                return IntStream.rangeClosed(start, end)
-                        .mapToObj(year -> Map.entry(year, project));
-            })
-            .collect(Collectors.groupingBy(
-                    Map.Entry::getKey,
-                    Collectors.mapping(Map.Entry::getValue, Collectors.toList())
-            ))
-            .entrySet()
-            .stream()
-            .sorted(Map.Entry.<Integer, List<ProjectEntity>>comparingByKey().reversed())
-            .map(entry -> new ProjectGroupByYearResponse(
-                    entry.getKey(),
-                    entry.getValue()
-                            .stream()
-                            .map(ProjectGroupByYearResponse.ProjectItem::new)
-                            .toList()
-            ))
-            .toList();
-}
+                    return IntStream.rangeClosed(start, end)
+                            .mapToObj(year -> Map.entry(year, project));
+                })
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+                ))
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry.<Integer, List<ProjectEntity>>comparingByKey().reversed())
+                .map(entry -> new ProjectGroupByYearResponse(
+                        entry.getKey(),
+                       entry.getValue()
+                        .stream()
+                        .sorted(Comparator.comparingLong(ProjectEntity::getId))
+                        .map(ProjectGroupByYearResponse.ProjectItem::new)
+                        .toList()
+                ))
+                .toList();
+    }
 }


### PR DESCRIPTION
# 📝 PR Summary
- 프로젝트별 메뉴에서 회의록/품의서 데이터 리스트를 조회하는 기능
- 미리보기 모달에서 해당하는 문서의 데이터를 조회하는 기능
- 프로젝트 페이지 내에 회의록 문서 연 

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#201-overview-preview

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 문서 데이터 카드 리스트에 연결
- [x] 해당 문서 미리보기 기능

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #201 

<!-- * @JakePark929 README작성. -->
