### PR TITLE
[ERROR / BUG] 회의 참여 가능 리스트 API 수정

### DIFF
--- a/wise-office-server/src/main/java/kr/co/wise/office/application/ProposalAttendantsServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/ProposalAttendantsServiceApi.java
@@ -7,7 +7,6 @@ import kr.co.wise.office.domain.Project.entity.ProjectEntity;
 import kr.co.wise.office.domain.attendant.service.AttendantService;
 import kr.co.wise.office.domain.member.entity.MemberEntity;
 import kr.co.wise.office.domain.member.service.MemberService;
-import kr.co.wise.office.domain.minutesattendant.entity.MinutesAttendantEntity;
 import kr.co.wise.office.domain.minutesattendant.service.MinutesAttendantsService;
 import kr.co.wise.office.domain.proposalattendant.entity.ProposalAttendantEntity;
 import kr.co.wise.office.domain.proposalattendant.service.ProposalAttendantsService;
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,13 +44,10 @@ public class ProposalAttendantsServiceApi {
         List<ProposalAttendantEntity> proposalAttendants = proposalAttendantsService.findByProjectId(projectId);
 
         // 회의 생성 당일날 다른 회의에 참석 중인 리스트 조회
-        List<MinutesAttendantEntity> busyAttendants = minutesAttendantsService.findByProposalAndMinutesDate(proposalAttendants, minutesDate);
-
-        // 금일 다른 회의에 참석중인 사람들의 id
-        Set<Long> busyIds = busyAttendants.stream().map(m -> m.getProposalAttendantEntity().getId()).collect(Collectors.toSet());
+        Set<Long> busyAttendants = minutesAttendantsService.findOverlappingMembers(minutesDate);
 
         List<PossibleAttendantsResponse> statusList = proposalAttendants.stream().map(pa -> {
-            boolean canAttend = !busyIds.contains(pa.getId());
+            boolean canAttend = !busyAttendants.contains(pa.getCompanyMember().getId());
             return new PossibleAttendantsResponse(pa.getCompanyMember().getId(),pa.getCompanyMember().getName(), canAttend);
         }).toList();
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/repository/MinutesAttendantEntityRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/repository/MinutesAttendantEntityRepository.java
@@ -1,7 +1,6 @@
 package kr.co.wise.office.domain.minutesattendant.repository;
 
 import kr.co.wise.office.domain.minutesattendant.entity.MinutesAttendantEntity;
-import kr.co.wise.office.domain.proposalattendant.entity.ProposalAttendantEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,14 +8,17 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public interface MinutesAttendantEntityRepository extends JpaRepository<MinutesAttendantEntity, Long> {
 
 
-    @Query("select m from MinutesAttendantEntity m join fetch m.minutesEntity mm where m.proposalAttendantEntity in :entity " +
-            "and m.minutesEntity.minutesDate = :minutesDate")
-    List<MinutesAttendantEntity> findByProposalAndMinutesDate(
-            @Param("entity") List<ProposalAttendantEntity> proposalAttendants,
+    @Query("select distinct cm.id from MinutesAttendantEntity m " +
+            "join m.minutesEntity mm " +
+            "join m.proposalAttendantEntity p " +
+            "join m.proposalAttendantEntity.companyMember cm " +
+            "where m.minutesEntity.minutesDate = :minutesDate")
+    Set<Long> findOverlappingMembers(
             @Param("minutesDate")LocalDate minutesDate
     );
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/repository/MinutesAttendantEntityRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/repository/MinutesAttendantEntityRepository.java
@@ -16,8 +16,8 @@ public interface MinutesAttendantEntityRepository extends JpaRepository<MinutesA
     @Query("select distinct cm.id from MinutesAttendantEntity m " +
             "join m.minutesEntity mm " +
             "join m.proposalAttendantEntity p " +
-            "join m.proposalAttendantEntity.companyMember cm " +
-            "where m.minutesEntity.minutesDate = :minutesDate")
+            "join p.companyMember cm " +
+            "where mm.minutesDate = :minutesDate")
     Set<Long> findOverlappingMembers(
             @Param("minutesDate")LocalDate minutesDate
     );

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/service/MinutesAttendantsService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/minutesattendant/service/MinutesAttendantsService.java
@@ -54,9 +54,8 @@ public class MinutesAttendantsService {
         attendantEntityRepository.saveAll(minutesAttendants);
     }
 
-    public List<MinutesAttendantEntity> findByProposalAndMinutesDate(List<ProposalAttendantEntity> attendants,
-                                                                     LocalDate minutesDate) {
-        return attendantEntityRepository.findByProposalAndMinutesDate(attendants, minutesDate);
+    public Set<Long> findOverlappingMembers(LocalDate minutesDate) {
+        return attendantEntityRepository.findOverlappingMembers(minutesDate);
     }
 
     public void updateMinutesAttendants(MinutesEntity minutes, String minutesAttendants, String writer, long projectId) {

--- a/wise-office-server/src/test/java/kr/co/wise/office/application/ProposalAttendantsServiceApiTest.java
+++ b/wise-office-server/src/test/java/kr/co/wise/office/application/ProposalAttendantsServiceApiTest.java
@@ -1,0 +1,177 @@
+package kr.co.wise.office.application;
+
+import kr.co.wise.office.api.dto.minutes.MinutesCreateRequest;
+import kr.co.wise.office.api.dto.proposal_attendant.PossibleAttendantsResponse;
+import kr.co.wise.office.domain.Project.entity.ProjectEntity;
+import kr.co.wise.office.domain.companymember.entity.CompanyMemberEntity;
+import kr.co.wise.office.domain.companymember.repository.CompanyMemberEntityRepository;
+import kr.co.wise.office.domain.minutes.entity.MinutesEntity;
+import kr.co.wise.office.domain.minutes.repository.MinutesEntityRepository;
+import kr.co.wise.office.domain.minutesattendant.entity.MinutesAttendantEntity;
+import kr.co.wise.office.domain.minutesattendant.repository.MinutesAttendantEntityRepository;
+import kr.co.wise.office.domain.proposalattendant.entity.ProposalAttendantEntity;
+import kr.co.wise.office.domain.proposalattendant.repository.ProposalAttendantEntityRepository;
+import kr.co.wise.office.security.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+class ProposalAttendantsServiceApiTest extends BaseTestEntity {
+
+    @Autowired
+    private ProposalAttendantsServiceApi proposalAttendantsServiceApi;
+
+    @Autowired
+    private CompanyMemberEntityRepository companyMemberEntityRepository;
+
+    @Autowired
+    private ProposalAttendantEntityRepository proposalAttendantEntityRepository;
+
+    @Autowired
+    private MinutesEntityRepository minutesEntityRepository;
+
+    @Autowired
+    private MinutesAttendantEntityRepository minutesAttendantEntityRepository;
+
+    @Test
+    @DisplayName("동일한 프로젝트의 회의가 잡힌 날짜에는 해당 참석자를 새로운 회의에 참여할 수 없도록 조회된다")
+    @WithMockCustomUser(email = "creator@test.co.kr")
+    void findPossibleAttendants_1() {
+        //given
+        final LocalDate minutesDate = BASE_DATE.plusDays(2);
+        ProjectEntity targetProject = projectRepository.findById(projectId).orElseThrow();
+        CompanyMemberEntity gildong = saveCompanyMember("홍길동");
+        CompanyMemberEntity minsu = saveCompanyMember("김민수");
+        ProposalAttendantEntity gilDongAttend = saveProposalAttendant(targetProject, gildong);
+        ProposalAttendantEntity minSuAttend = saveProposalAttendant(targetProject, minsu);
+
+        MinutesEntity minutes = saveMinutes(targetProject, minutesDate);
+        saveMinutesAttendants(minutes, gilDongAttend);
+
+        em.flush();
+        em.clear();
+
+        //when
+        List<PossibleAttendantsResponse> possibleAttendants = proposalAttendantsServiceApi.findPossibleAttendants(
+                targetProject.getId(),
+                minutesDate,
+                creator.getEmail()
+        );
+
+        //then : 민수는 회의 참석 가능
+        assertThat(possibleAttendants).hasSize(2);
+        assertThat(possibleAttendants)
+                .extracting(
+                        PossibleAttendantsResponse::memberId,
+                        PossibleAttendantsResponse::name,
+                        PossibleAttendantsResponse::canAttend
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(gildong.getId(), gildong.getName(), false),
+                        tuple(minsu.getId(), minsu.getName(), true)
+                );
+    }
+
+    @Test
+    @DisplayName("같은 날짜의 다른 프로젝트의 회의 참석자는 참석 불가로 조회된다")
+    @WithMockCustomUser(email = "creator@test.co.kr")
+    void findPossibleAttendants_2() {
+        // given
+        final LocalDate minutesDate = BASE_DATE.plusDays(2);
+        ProjectEntity targetProject = projectRepository.findById(projectId).orElseThrow();
+        CompanyMemberEntity gildong = saveCompanyMember("홍길동");
+        CompanyMemberEntity minsu = saveCompanyMember("김민수");
+        saveProposalAttendant(targetProject, gildong);
+        saveProposalAttendant(targetProject, minsu);
+
+        ProjectEntity anotherProject = saveProject("프로젝트2222");
+        ProposalAttendantEntity minsuAnthoerProjectAttend = saveProposalAttendant(anotherProject, minsu);
+        MinutesEntity sameDateMinutes = saveMinutes(anotherProject, minutesDate);
+        saveMinutesAttendants(sameDateMinutes, minsuAnthoerProjectAttend);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<PossibleAttendantsResponse> responses = proposalAttendantsServiceApi.findPossibleAttendants(
+                targetProject.getId(),
+                minutesDate,
+                creator.getEmail()
+        );
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses)
+                .extracting(
+                        PossibleAttendantsResponse::memberId,
+                        PossibleAttendantsResponse::name,
+                        PossibleAttendantsResponse::canAttend
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(gildong.getId(), gildong.getName(), true),
+                        tuple(minsu.getId(), minsu.getName(), false)
+                );
+    }
+
+    private CompanyMemberEntity saveCompanyMember(String name) {
+        return companyMemberEntityRepository.save(CompanyMemberEntity.builder()
+                .name(name)
+                .team("팀")
+                .rank("계급")
+                .build());
+    }
+
+    private ProposalAttendantEntity saveProposalAttendant(ProjectEntity project, CompanyMemberEntity companyMember) {
+        return proposalAttendantEntityRepository.save(ProposalAttendantEntity.builder()
+                .project(project)
+                .companyMember(companyMember)
+                .attendDate(BASE_DATE)
+                .build());
+    }
+
+    private ProjectEntity saveProject(String title) {
+        return projectRepository.save(ProjectEntity.builder()
+                .title(title)
+                .institution("기관")
+                .businessName("비즈니스")
+                .detail(title + " 설명")
+                .startYear(BASE_DATE)
+                .endYear(BASE_DATE.plusDays(10))
+                .member(creator)
+                .build());
+    }
+
+    private MinutesEntity saveMinutes(ProjectEntity project, LocalDate minutesDate) {
+        return minutesEntityRepository.save(MinutesEntity.from(
+                new MinutesCreateRequest(
+                        "주관",
+                        "장소",
+                        "목적",
+                        minutesDate,
+                        LocalTime.of(10, 0),
+                        LocalTime.of(11, 0),
+                        "",
+                        "이재용",
+                        "작성자",
+                        "콘텐츠"
+                ),
+                project,
+                minutesEntityRepository.countByMinutesDate(minutesDate) + 1L
+        ));
+    }
+
+    private void saveMinutesAttendants(MinutesEntity minutes, ProposalAttendantEntity... proposals) {
+        minutesAttendantEntityRepository.saveAll(
+                List.of(proposals).stream()
+                        .map(proposal -> new MinutesAttendantEntity(proposal, minutes))
+                        .toList()
+        );
+    }
+}

--- a/wise-office-server/src/test/resources/application.yml
+++ b/wise-office-server/src/test/resources/application.yml
@@ -54,7 +54,7 @@ domain:
   email: wise.co.kr
 
 image:
-  dir: C:/myVolumes/images
+  dir: ./build/test-images
   prefix: http://localhost:8080/images/
 
 holiday:

--- a/wise-office-server/src/test/resources/application.yml
+++ b/wise-office-server/src/test/resources/application.yml
@@ -1,0 +1,69 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+    defer-datasource-initialization: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test
+            client-secret: test
+            authorization-grant-type: authorization_code
+            redirect-uri: "testtestes/login/oauth2/code/{testsetes}"
+            scope: profile
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: testtest
+    password: testtest
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          timeout: 5000
+          connectiontimeout: 5000
+  servlet:
+    multipart:
+      max-file-size: 5MB
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+
+jwt:
+  secret: thisisfortestjwtjwtjwtjwtjwtjwtjwtjwt
+  expiration: 360000
+
+domain:
+  email: wise.co.kr
+
+image:
+  dir: C:/myVolumes/images
+  prefix: http://localhost:8080/images/
+
+holiday:
+  api:
+    key: test-key
+
+member:
+  init-path: init/memberList.txt
+
+front:
+  url: testtest
+  port: 3000


### PR DESCRIPTION
# 📝 PR Summary
- 두 프로젝트에서 같은 날에 회의가 동시에 수행되는 경우, 한 프로젝트에서 회의에 참여중일 떄 다른 프로젝트에서 회의 참석 가능 인원 조회시 이미 타 프로젝트의 회의에 참여중인 인원도 참석 가능으로 표시되는 문제 수정

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
fix/#253-minutes-attend-list


### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 서비스 로직 및 쿼리 수정
- [x] 테스트 코드 작성

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #253 

<!-- * @JakePark929 README작성. -->
