### PR TITLE
[FEATURE] 로그인 유지 연장 기능 추가

### DIFF
--- a/wise-office-client/src/components/header/ExtendLoginSession.tsx
+++ b/wise-office-client/src/components/header/ExtendLoginSession.tsx
@@ -1,0 +1,52 @@
+import { extendLoginSession } from "@/services/members";
+import { useEffect, useState } from "react";
+
+export default function ExtendLoginSession() {
+    const [expiredAt, setExpiredAt] = useState(
+        localStorage.getItem("expiredAt"),
+    );
+    const [timeLeft, setTimeLeft] = useState("");
+
+    useEffect(() => {
+        if (!expiredAt) return;
+
+        // 남은 시간을 계산하는 함수
+        const calculateTimeLeft = () => {
+            const expirationDate = new Date(expiredAt);
+            const now = new Date();
+            const difference = expirationDate.getTime() - now.getTime();
+
+            if (difference <= 0) {
+                setTimeLeft("만료됨");
+                return;
+            }
+
+            const minutes = Math.floor((difference / 1000 / 60) % 60);
+            const seconds = Math.floor((difference / 1000) % 60);
+
+            setTimeLeft(
+                `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`,
+            );
+        };
+        calculateTimeLeft();
+        const timer = setInterval(calculateTimeLeft, 1000);
+        return () => clearInterval(timer);
+    }, [expiredAt]);
+
+    const extendLogin = async () => {
+        const result = confirm("로그인을 연장하시겠습니까?");
+        if (result) {
+            const newExpiredAt = await extendLoginSession();
+            localStorage.setItem("expiredAt", newExpiredAt!);
+            setExpiredAt(newExpiredAt);
+        }
+    };
+
+    return (
+        <button onClick={() => extendLogin()}>
+            <span className="px-4 py-2 text-sm font-medium text-blue-700 bg-white rounded-md cursor-pointer hover:bg-gray-100">
+                {timeLeft}
+            </span>
+        </button>
+    );
+}

--- a/wise-office-client/src/components/header/ExtendLoginSession.tsx
+++ b/wise-office-client/src/components/header/ExtendLoginSession.tsx
@@ -2,13 +2,18 @@ import { extendLoginSession } from "@/services/members";
 import { useEffect, useState } from "react";
 
 export default function ExtendLoginSession() {
-    const [expiredAt, setExpiredAt] = useState(
-        localStorage.getItem("expiredAt"),
-    );
+    const [expiredAt, setExpiredAt] = useState<string | null>(null);
     const [timeLeft, setTimeLeft] = useState("");
 
     useEffect(() => {
-        if (!expiredAt) return;
+        setExpiredAt(localStorage.getItem("expiredAt"));
+    }, []);
+
+    useEffect(() => {
+        if (!expiredAt) {
+            setTimeLeft("");
+            return;
+        }
 
         // 남은 시간을 계산하는 함수
         const calculateTimeLeft = () => {
@@ -18,7 +23,7 @@ export default function ExtendLoginSession() {
 
             if (difference <= 0) {
                 setTimeLeft("만료됨");
-                return;
+                return true;
             }
 
             const minutes = Math.floor((difference / 1000 / 60) % 60);
@@ -27,18 +32,35 @@ export default function ExtendLoginSession() {
             setTimeLeft(
                 `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`,
             );
+
+            return false;
         };
-        calculateTimeLeft();
-        const timer = setInterval(calculateTimeLeft, 1000);
+
+        //만료된 경우 타이머 동작 X
+        if (calculateTimeLeft()) {
+            return;
+        }
+
+        const timer = setInterval(() => {
+            if (calculateTimeLeft()) {
+                clearInterval(timer);
+            }
+        }, 1000);
+
         return () => clearInterval(timer);
     }, [expiredAt]);
 
     const extendLogin = async () => {
         const result = confirm("로그인을 연장하시겠습니까?");
         if (result) {
-            const newExpiredAt = await extendLoginSession();
-            localStorage.setItem("expiredAt", newExpiredAt!);
-            setExpiredAt(newExpiredAt);
+            try {
+                const newExpiredAt = await extendLoginSession();
+                localStorage.setItem("expiredAt", newExpiredAt);
+                setExpiredAt(newExpiredAt);
+            } catch (err) {
+                console.error("로그인 연장 실패 : ", err);
+                alert("로그인 연장이 실패했습니다.");
+            }
         }
     };
 

--- a/wise-office-client/src/components/header/HeaderAuth.tsx
+++ b/wise-office-client/src/components/header/HeaderAuth.tsx
@@ -1,9 +1,10 @@
-import { useRouter } from "next/router";
-import Link from "next/link";
 import LogoutButton from "@/components/header/LogoutButton";
-import ProfileImage from "./ProfileImage";
 import { useAuthStore } from "@/store/useAuthStore";
 import { useProfileStore } from "@/store/useProfileStore";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import ExtendLoginSession from "./ExtendLoginSession";
+import ProfileImage from "./ProfileImage";
 
 export default function HeaderAuth() {
     const router = useRouter();
@@ -34,6 +35,7 @@ export default function HeaderAuth() {
             >
                 <ProfileImage imageUrl={profile?.imageUrl} />
             </div>
+            <ExtendLoginSession />
             <LogoutButton />
         </div>
     );

--- a/wise-office-client/src/services/members.ts
+++ b/wise-office-client/src/services/members.ts
@@ -117,9 +117,6 @@ export async function changePassword(req: ChangePasswordForm): Promise<void> {
 
 //로그인 연장 요청
 export async function extendLoginSession(): Promise<string> {
-    const result = await api
-        .post<LoginResponse>("/members/extend")
-        .then((res) => res.data.expiredAt);
-
-    return result;
+    const { data } = await api.post<LoginResponse>("/members/extend");
+    return data.expiredAt;
 }

--- a/wise-office-client/src/services/members.ts
+++ b/wise-office-client/src/services/members.ts
@@ -3,6 +3,7 @@ import {
     ChangePasswordForm,
     EmailVerificationResponse,
     GroupedMember,
+    LoginResponse,
     SignupForm,
 } from "@/types/member";
 import { Profile, ProfileRequest } from "@/types/profile";
@@ -112,4 +113,13 @@ export async function verifyFindPasswordCode(
 // 비밀번호 변경 요청
 export async function changePassword(req: ChangePasswordForm): Promise<void> {
     await api.patch("/members/email/find-password/verification", req);
+}
+
+//로그인 연장 요청
+export async function extendLoginSession(): Promise<string> {
+    const result = await api
+        .post<LoginResponse>("/members/extend")
+        .then((res) => res.data.expiredAt);
+
+    return result;
 }

--- a/wise-office-client/src/types/member.ts
+++ b/wise-office-client/src/types/member.ts
@@ -29,3 +29,7 @@ export type ChangePasswordForm = {
     password: string;
     passwordCheck: string;
 };
+
+export type LoginResponse = {
+    expiredAt: string;
+};

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
@@ -19,6 +19,7 @@ import kr.co.wise.office.domain.member.dto.*;
 import kr.co.wise.office.domain.member.service.MemberService;
 import kr.co.wise.office.exception.ErrorMessage;
 import kr.co.wise.office.exception.custom.ApplicationRuntimeException;
+import kr.co.wise.office.util.CookieUtils;
 import kr.co.wise.office.util.JWTUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,8 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-
-import static kr.co.wise.office.util.Constants.COOKIE_EXPIRATION_MINUTES;
 
 @Tag(name = "member", description = "회원 조회 관련 API 입니다.")
 @RestController
@@ -110,14 +109,10 @@ public class MemberController {
 
         //JWT 토큰 재발급
         String extendedJWT = JWTUtil.createJWT(email, role);
-        Cookie cookie = new Cookie("jwt", extendedJWT);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        cookie.setPath("/");
-        cookie.setMaxAge(COOKIE_EXPIRATION_MINUTES);
+        Cookie cookie = CookieUtils.createCookie("jwt", extendedJWT);
         response.addCookie(cookie);
 
-        return ResponseEntity.ok(new LoginResponse(LocalDateTime.now().plusSeconds(COOKIE_EXPIRATION_MINUTES)));
+        return ResponseEntity.ok(new LoginResponse(LocalDateTime.now().plusSeconds(CookieUtils.COOKIE_EXPIRATION_SECONDES)));
     }
 
     @PostMapping("/login")

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
@@ -19,6 +19,7 @@ import kr.co.wise.office.domain.member.dto.*;
 import kr.co.wise.office.domain.member.service.MemberService;
 import kr.co.wise.office.exception.ErrorMessage;
 import kr.co.wise.office.exception.custom.ApplicationRuntimeException;
+import kr.co.wise.office.util.JWTUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static kr.co.wise.office.util.Constants.COOKIE_EXPIRATION_MINUTES;
 
 @Tag(name = "member", description = "회원 조회 관련 API 입니다.")
 @RestController
@@ -93,6 +97,27 @@ public class MemberController {
         // null로 저장하면 프론트에서 default 이미지 보여줌
         memberService.signUp(signUpRequest, null);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/extend")
+    @Operation(summary = "로그인 연장", description = "로그인 시간을 30분 연장 합니다.")
+    public ResponseEntity<LoginResponse> extendLogin(
+            @Parameter(hidden = true) HttpServletResponse response,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuthUser loginUser
+    ) {
+        String email = loginUser.getName();
+        String role = loginUser.getAuthorities().iterator().next().getAuthority();
+
+        //JWT 토큰 재발급
+        String extendedJWT = JWTUtil.createJWT(email, role);
+        Cookie cookie = new Cookie("jwt", extendedJWT);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(COOKIE_EXPIRATION_MINUTES);
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok(new LoginResponse(LocalDateTime.now().plusSeconds(COOKIE_EXPIRATION_MINUTES)));
     }
 
     @PostMapping("/login")

--- a/wise-office-server/src/main/java/kr/co/wise/office/security/handler/CustomLoginSuccessHandler.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/security/handler/CustomLoginSuccessHandler.java
@@ -18,12 +18,13 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.time.LocalDateTime;
 
+import static kr.co.wise.office.util.Constants.COOKIE_EXPIRATION_MINUTES;
+
 @Component
 @Qualifier("customLoginSuccessHandler")
 @AllArgsConstructor
 public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler  {
 
-    private static final int COOKIE_EXPIRE_SECOND = 1800;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -32,13 +33,13 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler  
         String role = authentication.getAuthorities().iterator().next().getAuthority();
 
         String token = JWTUtil.createJWT(email, role);
-        LoginResponse loginResponse = new LoginResponse(LocalDateTime.now().plusSeconds(COOKIE_EXPIRE_SECOND));
+        LoginResponse loginResponse = new LoginResponse(LocalDateTime.now().plusSeconds(COOKIE_EXPIRATION_MINUTES));
 
         Cookie cookie = new Cookie("jwt", token);
         cookie.setHttpOnly(true);
         cookie.setSecure(false);
         cookie.setPath("/");
-        cookie.setMaxAge(COOKIE_EXPIRE_SECOND);
+        cookie.setMaxAge(COOKIE_EXPIRATION_MINUTES);
         String body = objectMapper.writeValueAsString(loginResponse);
 
         response.setStatus(HttpStatus.OK.value());

--- a/wise-office-server/src/main/java/kr/co/wise/office/security/handler/CustomLoginSuccessHandler.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/security/handler/CustomLoginSuccessHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.wise.office.domain.member.dto.LoginResponse;
+import kr.co.wise.office.util.CookieUtils;
 import kr.co.wise.office.util.JWTUtil;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,8 +18,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-
-import static kr.co.wise.office.util.Constants.COOKIE_EXPIRATION_MINUTES;
 
 @Component
 @Qualifier("customLoginSuccessHandler")
@@ -33,15 +32,11 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler  
         String role = authentication.getAuthorities().iterator().next().getAuthority();
 
         String token = JWTUtil.createJWT(email, role);
-        LoginResponse loginResponse = new LoginResponse(LocalDateTime.now().plusSeconds(COOKIE_EXPIRATION_MINUTES));
 
-        Cookie cookie = new Cookie("jwt", token);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        cookie.setPath("/");
-        cookie.setMaxAge(COOKIE_EXPIRATION_MINUTES);
+        Cookie cookie = CookieUtils.createCookie("jwt", token);
+        LoginResponse loginResponse = new LoginResponse(LocalDateTime.now().plusSeconds(CookieUtils.COOKIE_EXPIRATION_SECONDES));
+
         String body = objectMapper.writeValueAsString(loginResponse);
-
         response.setStatus(HttpStatus.OK.value());
         response.addCookie(cookie);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/wise-office-server/src/main/java/kr/co/wise/office/util/Constants.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/util/Constants.java
@@ -1,9 +1,0 @@
-package kr.co.wise.office.util;
-
-public abstract class Constants {
-
-    public static final int COOKIE_EXPIRATION_MINUTES = 1800;
-
-    private Constants() {}
-
-}

--- a/wise-office-server/src/main/java/kr/co/wise/office/util/Constants.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/util/Constants.java
@@ -1,0 +1,9 @@
+package kr.co.wise.office.util;
+
+public abstract class Constants {
+
+    public static final int COOKIE_EXPIRATION_MINUTES = 1800;
+
+    private Constants() {}
+
+}

--- a/wise-office-server/src/main/java/kr/co/wise/office/util/CookieUtils.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/util/CookieUtils.java
@@ -1,0 +1,25 @@
+package kr.co.wise.office.util;
+
+import jakarta.servlet.http.Cookie;
+
+public abstract class CookieUtils {
+
+    public static final int COOKIE_EXPIRATION_SECONDES = 1800;
+
+    public static Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // http 환경에서 사용
+        cookie.setPath("/");
+        cookie.setMaxAge(COOKIE_EXPIRATION_SECONDES);
+        return cookie;
+    }
+
+    public static Cookie createCookie(String key, String value, int age) {
+        Cookie cookie = createCookie(key, value);
+        cookie.setMaxAge(age);
+        return cookie;
+    }
+
+    private CookieUtils() {}
+}

--- a/wise-office-server/src/main/resources/application.yml
+++ b/wise-office-server/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: 180000000
+  expiration: 1800000
       
 domain:
   email: all

--- a/wise-office-server/src/main/resources/application.yml
+++ b/wise-office-server/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: 360000000
+  expiration: 180000000
       
 domain:
   email: all


### PR DESCRIPTION
# 📝 PR Summary
- 버튼을 통한 로그인 연장 기능 추가

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#279-extend-login-session

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 클라이언트 : 로그인시 헤더에 연장 버튼 추가 => 클릭시 30분 연장
- [x] 서버 : 연장 API 추가

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #279 

<!-- * @JakePark929 README작성. -->
