### PR TITLE
[REFACTOR] 마이페이지 정보 변경 로직 리팩토링

### DIFF
--- a/wise-office-client/src/components/account/ProjectCardsMy.tsx
+++ b/wise-office-client/src/components/account/ProjectCardsMy.tsx
@@ -14,7 +14,7 @@ export default function ProjectCardsMy({ props }: UserProfileProps) {
             <h2 className="text-blue-700 font-bold text-xl mb-6 border-b border-blue-200 pb-2">
                 수행 중인 프로젝트
             </h2>
-            <ul className="space-y-4 max-h-120 md:max-h-[400px] overflow-y-auto pt-1">
+            <ul className="space-y-4 max-h-120 md:max-h-[500px] overflow-y-auto pt-1">
                 {projects && projects.length > 0 ? (
                     projects.map((project, index) => (
                         <li key={index}>

--- a/wise-office-client/src/pages/account/index.tsx
+++ b/wise-office-client/src/pages/account/index.tsx
@@ -8,6 +8,7 @@ import {
     getMyProfile,
     logout,
     updateMemberAccount,
+    updatePassword,
 } from "@/services/members";
 import { Profile } from "@/types/profile";
 import { getErrorMessage } from "@/utils/ErrorParser";
@@ -34,7 +35,7 @@ export default function Account() {
         fetchData();
     }, []);
 
-    const handleUpdateAccountInfo = async () => {
+    const handleUpdatePassword = async () => {
         const MIN_PASSWORD_LENGTH = 8;
         const MAX_PASSWORD_LENGTH = 20;
 
@@ -56,23 +57,32 @@ export default function Account() {
         }
 
         try {
-            const res = await updateMemberAccount({
+            await updatePassword({
+                password: newPassword,
+                passwordCheck: newPasswordCheck,
+            });
+            logout();
+            toastMessage.success("변경된 비밀번호로 다시 로그인해 주세요.");
+            router.push("/auth/login");
+        } catch (error) {
+            const errorMessage = getErrorMessage(error);
+            toastMessage.error(errorMessage, {
+                style: { whiteSpace: "pre-line" },
+            });
+        }
+    };
+
+    const handleUpdateAccountInfo = async () => {
+        try {
+            await updateMemberAccount({
                 team,
                 rank,
                 hireDate: joinDate || undefined,
-                password: newPassword || undefined,
-                passwordCheck: newPasswordCheck || undefined,
             });
 
-            if (res.passwordChanged) {
-                await logout();
-                router.push("/auth/login");
-            } else {
-                toastMessage.success("정보가 저장되었습니다.");
-            }
+            toastMessage.success("정보가 저장되었습니다.");
         } catch (error) {
             const errorMessage = getErrorMessage(error);
-            console.error(error);
             toastMessage.error(errorMessage, {
                 style: { whiteSpace: "pre-line" },
             });
@@ -89,6 +99,7 @@ export default function Account() {
 
                 {/* 개인정보 확인 및 변경 영역 */}
                 <section className="col-span-12 md:col-span-3 bg-white rounded-lg shadow-md p-6 flex flex-col justify-center space-y-6 mb-6">
+                    {/* 회사 정보 영역 */}
                     {profile && (
                         <MyInfo
                             team={team}
@@ -104,37 +115,42 @@ export default function Account() {
                         onChange={setJoinDate}
                         page="account"
                     />
-                    <div>
-                        <div className="mb-4">
-                            <label className="block text-gray-700 font-semibold mb-2">
-                                비밀번호 변경
-                            </label>
-                            <input
-                                type="password"
-                                className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                value={newPassword || ""}
-                                onChange={(e) => setNewPassword(e.target.value)}
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-gray-700 font-semibold mb-2">
-                                비밀번호 변경 확인
-                            </label>
-                            <input
-                                type="password"
-                                className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                                value={newPasswordCheck || ""}
-                                onChange={(e) =>
-                                    setNewPasswordCheck(e.target.value)
-                                }
-                            />
-                        </div>
-                    </div>
                     <button
                         onClick={handleUpdateAccountInfo}
                         className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded py-2 transition duration-300 cursor-pointer"
                     >
-                        정보 변경하기
+                        인사 정보 변경
+                    </button>
+                    {/* 비밀번호 변경 영역 */}
+                    <div className="mb-4">
+                        <label className="block text-gray-700 font-semibold mb-2">
+                            비밀번호 변경
+                        </label>
+                        <input
+                            type="password"
+                            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                            value={newPassword || ""}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-gray-700 font-semibold mb-2">
+                            비밀번호 변경 확인
+                        </label>
+                        <input
+                            type="password"
+                            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                            value={newPasswordCheck || ""}
+                            onChange={(e) =>
+                                setNewPasswordCheck(e.target.value)
+                            }
+                        />
+                    </div>
+                    <button
+                        onClick={handleUpdatePassword}
+                        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded py-2 transition duration-300 cursor-pointer"
+                    >
+                        비밀번호 변경
                     </button>
                 </section>
 

--- a/wise-office-client/src/pages/account/index.tsx
+++ b/wise-office-client/src/pages/account/index.tsx
@@ -61,7 +61,7 @@ export default function Account() {
                 password: newPassword,
                 passwordCheck: newPasswordCheck,
             });
-            logout();
+            await logout();
             toastMessage.success("변경된 비밀번호로 다시 로그인해 주세요.");
             router.push("/auth/login");
         } catch (error) {

--- a/wise-office-client/src/pages/auth/find-password.tsx
+++ b/wise-office-client/src/pages/auth/find-password.tsx
@@ -2,7 +2,7 @@ import { useCountDown } from "@/hooks/useCountDown";
 import { validateEmailForm, validateEmailLen } from "@/lib/auth/signup";
 import { toastMessage } from "@/lib/common/toastMessage";
 import {
-    changePassword,
+    resetPassword,
     requestFindPasswordCode,
     verifyFindPasswordCode,
 } from "@/services/members";
@@ -168,7 +168,7 @@ export default function FindPasswordPage() {
         setIsSubmitting(true);
 
         try {
-            await changePassword({
+            await resetPassword({
                 successToken,
                 password,
                 passwordCheck: passwordConfirm,

--- a/wise-office-client/src/services/members.ts
+++ b/wise-office-client/src/services/members.ts
@@ -1,11 +1,12 @@
 import { api } from "@/lib/clientApi";
 import {
-    ChangePasswordForm,
+    ChangePasswordRequest,
     EmailVerificationResponse,
     GroupedMember,
     LoginResponse,
     MemberAccountUpdateRequest,
     MemberAccountUpdateResponse,
+    ResetPasswordRequest,
     SignupForm,
 } from "@/types/member";
 import { Profile, ProfileRequest } from "@/types/profile";
@@ -123,8 +124,8 @@ export async function updateMemberAccount(
     return data;
 }
 
-// 비밀번호 변경 요청
-export async function changePassword(req: ChangePasswordForm): Promise<void> {
+// 비밀번호 초기화 요청
+export async function resetPassword(req: ResetPasswordRequest): Promise<void> {
     await api.patch("/members/email/find-password/verification", req);
 }
 
@@ -132,4 +133,11 @@ export async function changePassword(req: ChangePasswordForm): Promise<void> {
 export async function extendLoginSession(): Promise<string> {
     const { data } = await api.post<LoginResponse>("/members/extend");
     return data.expiredAt;
+}
+
+// 비밀번호 변경 요청
+export async function updatePassword(
+    req: ChangePasswordRequest,
+): Promise<void> {
+    await api.patch("/members/password", req);
 }

--- a/wise-office-client/src/types/member.ts
+++ b/wise-office-client/src/types/member.ts
@@ -25,8 +25,13 @@ export type EmailVerificationResponse = {
     successCode: string;
 };
 
-export type ChangePasswordForm = {
+export type ResetPasswordRequest = {
     successToken: string;
+    password: string;
+    passwordCheck: string;
+};
+
+export type ChangePasswordRequest = {
     password: string;
     passwordCheck: string;
 };
@@ -39,8 +44,6 @@ export type MemberAccountUpdateRequest = {
     team?: string;
     rank?: string;
     hireDate?: string;
-    password?: string;
-    passwordCheck?: string;
 };
 
 export type MemberAccountUpdateResponse = {

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
@@ -147,11 +147,22 @@ public class MemberController {
 
     @PatchMapping("/account")
     @Operation(summary = "계정 정보 수정", description = "부서, 직급, 입사일, 비밀번호를 수정합니다. 변경된 값만 업데이트됩니다.")
-    public ResponseEntity<MemberUpdateResponse> updateAccountInfo(
+    public ResponseEntity<Void> updateAccountInfo(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuthUser loginUser,
             @RequestBody @Valid MemberUpdateRequest request) {
-        MemberUpdateResponse response = memberService.updateMember(loginUser.getName(), request);
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+
+        memberService.updateMember(loginUser.getName(), request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PatchMapping("/password")
+    @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경합니다.")
+    public ResponseEntity<Void> updatePassword(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuthUser loginUser,
+            @RequestBody @Valid ChangePasswordRequest request
+    ) {
+        memberService.changePassword(loginUser.getName(), request.password(), request.passwordCheck());
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/hire-date")
@@ -189,8 +200,8 @@ public class MemberController {
 
     @PatchMapping("/email/find-password/verification")
     @Operation(summary = "비밀번호 초기화")
-    public ResponseEntity<Void> changePassword(
-            @Parameter(description = "비밀번호 초기화") @RequestBody ChangePasswordRequest request
+    public ResponseEntity<Void> resetPassword(
+            @Parameter(description = "비밀번호 초기화") @RequestBody ResetPasswordRequest request
     ) {
         String email = emailService.verificationSuccessToken(request.successToken());
         memberService.changePassword(email, request.password(), request.passwordCheck());

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/MemberController.java
@@ -146,7 +146,7 @@ public class MemberController {
     }
 
     @PatchMapping("/account")
-    @Operation(summary = "계정 정보 수정", description = "부서, 직급, 입사일, 비밀번호를 수정합니다. 변경된 값만 업데이트됩니다.")
+    @Operation(summary = "계정 정보 수정", description = "부서, 직급, 입사일을 수정합니다. 사용자가 변경된 값만 업데이트됩니다.")
     public ResponseEntity<Void> updateAccountInfo(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomOAuthUser loginUser,
             @RequestBody @Valid MemberUpdateRequest request) {

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ChangePasswordRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ChangePasswordRequest.java
@@ -1,7 +1,8 @@
 package kr.co.wise.office.domain.member.dto;
 
+import jakarta.validation.constraints.Size;
+
 public record ChangePasswordRequest(
-        String successToken,
-        String password,
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해 주세요.") String password,
         String passwordCheck
 ) { }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ChangePasswordRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ChangePasswordRequest.java
@@ -1,8 +1,13 @@
 package kr.co.wise.office.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ChangePasswordRequest(
-        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해 주세요.") String password,
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해 주세요.")
+        String password,
+        @NotBlank(message = "비밀번호 확인을 입력해주세요")
+        @Size(min = 8, max = 20, message = "비밀번호 확인은 8자 이상, 20자 이하로 비밀번호와 동일한 값을 입력해 주세요.")
         String passwordCheck
 ) { }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/MemberUpdateRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/MemberUpdateRequest.java
@@ -1,7 +1,6 @@
 package kr.co.wise.office.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
@@ -9,7 +8,5 @@ public record MemberUpdateRequest(
         String team,
         String rank,
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate hireDate,
-        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해 주세요.") String password,
-        String passwordCheck
+        LocalDate hireDate
 ) {}

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ResetPasswordRequest.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/dto/ResetPasswordRequest.java
@@ -1,0 +1,7 @@
+package kr.co.wise.office.domain.member.dto;
+
+public record ResetPasswordRequest(
+        String successToken,
+        String password,
+        String passwordCheck
+) { }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/member/service/MemberService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/member/service/MemberService.java
@@ -213,9 +213,8 @@ public class MemberService extends DefaultOAuth2UserService implements UserDetai
     }
 
     @Transactional
-    public MemberUpdateResponse updateMember(String email, MemberUpdateRequest req) {
+    public void updateMember(String email, MemberUpdateRequest req) {
         MemberEntity member = findUserWithEmail(email);
-        boolean passwordChanged = false; // 비밀번호 변경 유무
 
         // 바뀐 값만 변경되도록 수정 
         if (req.team() != null && !req.team().equals(member.getTeam())) {
@@ -229,14 +228,6 @@ public class MemberService extends DefaultOAuth2UserService implements UserDetai
         if (req.hireDate() != null && !req.hireDate().equals(member.getHireDate())) {
             member.updateHireDate(req.hireDate());
         }
-
-        if (req.password() != null && req.passwordCheck() != null) {
-            validatePassword(req.password(), req.passwordCheck());
-            member.updatePassword(passwordEncoder.encode(req.password()));
-            passwordChanged = true;
-        }
-
-        return new MemberUpdateResponse(passwordChanged);
     }
 
     @Transactional


### PR DESCRIPTION
# 📝 PR Summary
- 개인 정보 수정시 회사 정보 (직급, 소속, 입사일)과 계정 비밀번호를 별도의 버튼으로 분리하여 저장하도록 변경
 
### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#310-split-update-account

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 클라이언트 버튼 분리
- [x] 서버 API 분리

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #310 

<!-- * @JakePark929 README작성. -->
