### PR TITLE
[FEATURE] 문서 현황 페이지 월별 데이터 연동

### DIFF
--- a/wise-office-client/src/components/modal/minute/AttendanceModal.tsx
+++ b/wise-office-client/src/components/modal/minute/AttendanceModal.tsx
@@ -94,7 +94,7 @@ export default function AttendanceModal({
     };
 
     /* ------ ui ----- */
-    if (isLoading) return <LoadingIndicator type="minute" />;
+    if (isLoading) return <LoadingIndicator type="minutes" />;
 
     return (
         <div className="flex items-center justify-center">

--- a/wise-office-client/src/components/overview/Calendar.tsx
+++ b/wise-office-client/src/components/overview/Calendar.tsx
@@ -30,9 +30,9 @@ export default function Calendar() {
     }
 
     const changeMonth = (diff: number) => {
-        const newDate = new Date(year, month + diff, 1);
+        const newDate = new Date(year, month - 1 + diff, 1);
         setYear(newDate.getFullYear());
-        setMonth(newDate.getMonth());
+        setMonth(newDate.getMonth() + 1);
     };
 
     // 바깥 클릭 감지
@@ -113,7 +113,7 @@ export default function Calendar() {
                             }}
                             className="px-2 py-1 rounded-md hover:bg-gray-100 cursor-pointer"
                         >
-                            {month + 1}월
+                            {month}월
                         </button>
 
                         {openMonth && (

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -13,6 +13,7 @@ import {
     MonthlyDocument,
 } from "@/types/document";
 import OverviewCard from "./OverviewCard";
+import LoadingIndicator from "../ui/LoadingIndicator";
 
 export default function MonthOverviewList() {
     const { year, month, projectInfo } = useOverviewStore();
@@ -25,6 +26,7 @@ export default function MonthOverviewList() {
     const [approvalDetailList, setApprovalDetailList] = useState<
         ApprovalDetailResponse[]
     >([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         const fetchMinutes = async () => {
@@ -50,10 +52,13 @@ export default function MonthOverviewList() {
         };
 
         const fetchData = async () => {
+            setIsLoading(true);
             const projectList = await getMonthlyDocuments(year, month);
             setMonthlyDocumentList(projectList);
 
-            await Promise.all([fetchMinutes(), fetchApproves()]);
+            await Promise.all([fetchMinutes(), fetchApproves()]).finally(() =>
+                setIsLoading(false),
+            );
         };
 
         fetchData();
@@ -65,7 +70,11 @@ export default function MonthOverviewList() {
                 {year}년 {month}월
             </p>
 
-            {!monthlyDocumentList.length ? (
+            {isLoading ? (
+                <div className="-translate-y-30">
+                    <LoadingIndicator type="minutes" />
+                </div>
+            ) : !monthlyDocumentList.length ? (
                 <p className="text-gray-400">등록된 문서가 없습니다.</p>
             ) : (
                 monthlyDocumentList.map((documentList) => (

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -30,29 +30,27 @@ export default function MonthOverviewList() {
 
     useEffect(() => {
         const fetchMinutes = async (projectIds: number[]) => {
-            for (const projectId of projectIds) {
-                const data = await getMinutes(projectId);
-                const minutesDetailResponse = await Promise.all(
-                    data.map((m) => getMinutesInfo(projectId, m.minutesId)),
-                );
-                setMinutesDetailList((prev) => [
-                    ...prev,
-                    ...minutesDetailResponse,
-                ]);
-            }
+            const allDetails = await Promise.all(
+                projectIds.map(async (projectId) => {
+                    const data = await getMinutes(projectId);
+                    return Promise.all(
+                        data.map((m) => getMinutesInfo(projectId, m.minutesId)),
+                    );
+                }),
+            );
+            setMinutesDetailList(allDetails.flat());
         };
 
-        const fetchApproves = async (projectIds: number[]) => {
-            for (const projectId of projectIds) {
-                const data = await getApproves(projectId);
-                const approvalDetailResponse = await Promise.all(
-                    data.map((m) => getApproveInfo(projectId, m.approveId)),
-                );
-                setApprovalDetailList((prev) => [
-                    ...prev,
-                    ...approvalDetailResponse,
-                ]);
-            }
+        const fetchApprovals = async (projectIds: number[]) => {
+            const allDetails = await Promise.all(
+                projectIds.map(async (projectId) => {
+                    const data = await getApproves(projectId);
+                    return Promise.all(
+                        data.map((m) => getApproveInfo(projectId, m.approveId)),
+                    );
+                }),
+            );
+            setApprovalDetailList(allDetails.flat());
         };
 
         const fetchData = async () => {
@@ -67,12 +65,19 @@ export default function MonthOverviewList() {
 
             await Promise.all([
                 fetchMinutes(projectIds),
-                fetchApproves(projectIds),
+                fetchApprovals(projectIds),
             ]).finally(() => setIsLoading(false));
         };
 
         fetchData();
     }, [year, month]);
+
+    const minutesDetailMap = new Map(
+        minutesDetailList.map((m) => [m.minutesId, m]),
+    );
+    const approvalDetailMap = new Map(
+        approvalDetailList.map((a) => [a.minutesId, a]),
+    );
 
     return (
         <div className="flex flex-col gap-10">
@@ -89,7 +94,7 @@ export default function MonthOverviewList() {
             ) : (
                 monthlyDocumentList.map((documentList) => (
                     <div
-                        key={documentList.title}
+                        key={documentList.projectId}
                         className="flex flex-col gap-4 pr-16"
                     >
                         <p className="text-lg font-semibold">
@@ -97,15 +102,14 @@ export default function MonthOverviewList() {
                         </p>
 
                         {documentList.pair.map((document) => {
-                            const minutesDetail = minutesDetailList.find(
-                                (m) =>
-                                    m.minutesId ===
-                                    Number(document.minutes.minutesId),
+                            const minutesDetail = minutesDetailMap.get(
+                                Number(document.minutes.minutesId),
                             );
-                            const approvalDetail = approvalDetailList.find(
-                                (a) =>
-                                    a.approveId === document.approve?.approveId,
-                            );
+                            const approvalDetail = document.approve?.approveId
+                                ? approvalDetailMap.get(
+                                      document.approve.approveId,
+                                  )
+                                : undefined;
 
                             return (
                                 <div

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -114,7 +114,7 @@ export default function MonthOverviewList() {
                             return (
                                 <div
                                     key={document.minutes.minutesId}
-                                    className="flex flex-col gap-4 pr-16"
+                                    className="flex flex-col gap-3"
                                 >
                                     <OverviewCard
                                         minutesTitle={

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -76,7 +76,7 @@ export default function MonthOverviewList() {
         minutesDetailList.map((m) => [m.minutesId, m]),
     );
     const approvalDetailMap = new Map(
-        approvalDetailList.map((a) => [a.minutesId, a]),
+        approvalDetailList.map((a) => [a.approveId, a]),
     );
 
     return (

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -1,55 +1,111 @@
-// import OverviewCard from "./OverviewCard";
+import { useEffect, useState } from "react";
 import { useOverviewStore } from "@/store/useOverviewStore";
-import { MINUTES } from "@/lib/data/overview";
+import {
+    getApproveInfo,
+    getApproves,
+    getMinutes,
+    getMinutesInfo,
+    getMonthlyDocuments,
+} from "@/services/overview";
+import {
+    ApprovalDetailResponse,
+    MinutesInfo,
+    MonthlyDocument,
+} from "@/types/document";
+import OverviewCard from "./OverviewCard";
 
 export default function MonthOverviewList() {
-    const { year, month } = useOverviewStore();
+    const { year, month, projectInfo } = useOverviewStore();
+    const [monthlyDocumentList, setMonthlyDocumentList] = useState<
+        MonthlyDocument[]
+    >([]);
+    const [minutesDetailList, setMinutesDetailList] = useState<MinutesInfo[]>(
+        [],
+    );
+    const [approvalDetailList, setApprovalDetailList] = useState<
+        ApprovalDetailResponse[]
+    >([]);
 
-    const filteredData = MINUTES.filter(
-        (m) =>
-            m.minutes_date.getFullYear() === year &&
-            m.minutes_date.getMonth() === month,
-    ).map((minutes) => ({
-        minutes,
-    }));
+    useEffect(() => {
+        const fetchMinutes = async () => {
+            const data = await getMinutes(projectInfo.projectId);
+
+            const minutesDetailResponse = await Promise.all(
+                data.map((m) =>
+                    getMinutesInfo(projectInfo.projectId, m.minutesId),
+                ),
+            );
+            setMinutesDetailList(minutesDetailResponse);
+        };
+
+        const fetchApproves = async () => {
+            const data = await getApproves(projectInfo.projectId);
+
+            const approvalDetailResponse = await Promise.all(
+                data.map((m) =>
+                    getApproveInfo(projectInfo.projectId, m.approveId),
+                ),
+            );
+            setApprovalDetailList(approvalDetailResponse);
+        };
+
+        const fetchData = async () => {
+            const projectList = await getMonthlyDocuments(year, month);
+            setMonthlyDocumentList(projectList);
+
+            await Promise.all([fetchMinutes(), fetchApproves()]);
+        };
+
+        fetchData();
+    }, [year, month]);
 
     return (
         <div className="flex flex-col gap-10">
             <p className="text-2xl font-bold">
-                {year}년 {month + 1}월
+                {year}년 {month}월
             </p>
 
-            <div className="flex flex-col gap-4 pr-16">
-                {filteredData.map(({ minutes }, index) => (
+            {!monthlyDocumentList.length ? (
+                <p className="text-gray-400">등록된 문서가 없습니다.</p>
+            ) : (
+                monthlyDocumentList.map((documentList) => (
                     <div
-                        key={minutes.minutes_pk}
-                        className={`flex flex-col gap-3 ${
-                            index !== filteredData.length - 1
-                                ? "pb-4 border-b border-gray-200"
-                                : ""
-                        }`}
+                        key={documentList.title}
+                        className="flex flex-col gap-4 pr-16"
                     >
-                        {/* 다음 작업 예정 */}
-                        {/* <OverviewCard
-                            key={`${minutes.minutes_pk}-minutes`}
-                            minutes={{
-                                minutesId: minutes.minutes_pk,
-                                title: minutes.title,
-                                minutesAt: minutes.minutes_date.toISOString(),
-                            }}
-                        />
-                        <OverviewCard
-                            key={`${minutes.minutes_pk}-approval`}
-                            minutes={{
-                                minutesId: minutes.minutes_pk,
-                                title: minutes.title,
-                                minutesAt: minutes.minutes_date.toISOString(),
-                            }}
-                            isApproval={true}
-                        /> */}
+                        <p className="text-lg font-semibold">
+                            {documentList.title}
+                        </p>
+
+                        {documentList.pair.map((document) => {
+                            const minutesDetail = minutesDetailList.find(
+                                (m) =>
+                                    m.minutesId ===
+                                    Number(document.minutes.minutesId),
+                            );
+                            const approvalDetail = approvalDetailList.find(
+                                (a) =>
+                                    a.approveId === document.approve?.approveId,
+                            );
+
+                            return (
+                                <div
+                                    key={document.minutes.minutesId}
+                                    className="flex flex-col gap-4 pr-16"
+                                >
+                                    <OverviewCard
+                                        minutesTitle={
+                                            document.minutes.minutesTitle
+                                        }
+                                        minutesDetail={minutesDetail}
+                                        approvalDetail={approvalDetail}
+                                    />
+                                </div>
+                            );
+                        })}
                     </div>
-                ))}
-            </div>
+                ))
+            )}
         </div>
     );
 }

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -64,6 +64,8 @@ export default function MonthOverviewList() {
         fetchData();
     }, [year, month]);
 
+    console.log(projectInfo);
+
     return (
         <div className="flex flex-col gap-10">
             <p className="text-2xl font-bold">

--- a/wise-office-client/src/components/overview/MonthOverviewList.tsx
+++ b/wise-office-client/src/components/overview/MonthOverviewList.tsx
@@ -16,7 +16,7 @@ import OverviewCard from "./OverviewCard";
 import LoadingIndicator from "../ui/LoadingIndicator";
 
 export default function MonthOverviewList() {
-    const { year, month, projectInfo } = useOverviewStore();
+    const { year, month } = useOverviewStore();
     const [monthlyDocumentList, setMonthlyDocumentList] = useState<
         MonthlyDocument[]
     >([]);
@@ -29,42 +29,50 @@ export default function MonthOverviewList() {
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        const fetchMinutes = async () => {
-            const data = await getMinutes(projectInfo.projectId);
-
-            const minutesDetailResponse = await Promise.all(
-                data.map((m) =>
-                    getMinutesInfo(projectInfo.projectId, m.minutesId),
-                ),
-            );
-            setMinutesDetailList(minutesDetailResponse);
+        const fetchMinutes = async (projectIds: number[]) => {
+            for (const projectId of projectIds) {
+                const data = await getMinutes(projectId);
+                const minutesDetailResponse = await Promise.all(
+                    data.map((m) => getMinutesInfo(projectId, m.minutesId)),
+                );
+                setMinutesDetailList((prev) => [
+                    ...prev,
+                    ...minutesDetailResponse,
+                ]);
+            }
         };
 
-        const fetchApproves = async () => {
-            const data = await getApproves(projectInfo.projectId);
-
-            const approvalDetailResponse = await Promise.all(
-                data.map((m) =>
-                    getApproveInfo(projectInfo.projectId, m.approveId),
-                ),
-            );
-            setApprovalDetailList(approvalDetailResponse);
+        const fetchApproves = async (projectIds: number[]) => {
+            for (const projectId of projectIds) {
+                const data = await getApproves(projectId);
+                const approvalDetailResponse = await Promise.all(
+                    data.map((m) => getApproveInfo(projectId, m.approveId)),
+                );
+                setApprovalDetailList((prev) => [
+                    ...prev,
+                    ...approvalDetailResponse,
+                ]);
+            }
         };
 
         const fetchData = async () => {
             setIsLoading(true);
+            setMinutesDetailList([]);
+            setApprovalDetailList([]);
+
             const projectList = await getMonthlyDocuments(year, month);
             setMonthlyDocumentList(projectList);
 
-            await Promise.all([fetchMinutes(), fetchApproves()]).finally(() =>
-                setIsLoading(false),
-            );
+            const projectIds = projectList.map((m) => m.projectId);
+
+            await Promise.all([
+                fetchMinutes(projectIds),
+                fetchApproves(projectIds),
+            ]).finally(() => setIsLoading(false));
         };
 
         fetchData();
     }, [year, month]);
-
-    console.log(projectInfo);
 
     return (
         <div className="flex flex-col gap-10">

--- a/wise-office-client/src/components/overview/OverviewCard.tsx
+++ b/wise-office-client/src/components/overview/OverviewCard.tsx
@@ -1,19 +1,15 @@
 import PreviewButton from "@/components/ui/button/PreviewButton";
 import PrintButton from "@/components/ui/button/PrintButton";
-import {
-    ApprovalDetailResponse,
-    MinutesInfo,
-    MinutesItem,
-} from "@/types/document";
+import { ApprovalDetailResponse, MinutesInfo } from "@/types/document";
 
 interface OverviewCardProps {
-    minutesInfo: MinutesItem;
+    minutesTitle: string;
     minutesDetail?: MinutesInfo;
     approvalDetail?: ApprovalDetailResponse;
 }
 
 export default function OverviewCard({
-    minutesInfo,
+    minutesTitle,
     minutesDetail,
     approvalDetail,
 }: OverviewCardProps) {
@@ -32,7 +28,7 @@ export default function OverviewCard({
                     </div>
                     <div className="flex-1 flex px-2 py-3 items-center gap-6">
                         <p className="flex-1 flex justify-center text-sm">
-                            회의록 · {minutesInfo.title}
+                            회의록 · {minutesTitle}
                         </p>
                         <p className="flex-1 flex text-xs text-gray-600 line-clamp-3 break-keep">
                             {minutesDetail?.minutesAttendants

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -111,7 +111,7 @@ export default function ProjectOverviewList() {
                                         }`}
                                     >
                                         <OverviewCard
-                                            minutesInfo={info}
+                                            minutesTitle={info.title}
                                             minutesDetail={minutesDetail}
                                             approvalDetail={approvalDetail}
                                         />

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -12,6 +12,7 @@ import {
     MinutesInfo,
     MinutesList,
 } from "@/types/document";
+import LoadingIndicator from "../ui/LoadingIndicator";
 
 export default function ProjectOverviewList() {
     const { year, projectInfo } = useOverviewStore();
@@ -22,6 +23,7 @@ export default function ProjectOverviewList() {
     const [approvalDetailList, setApprovalDetailList] = useState<
         ApprovalDetailResponse[]
     >([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         const fetchMinutes = async () => {
@@ -50,8 +52,11 @@ export default function ProjectOverviewList() {
         };
 
         if (projectInfo.projectId) {
-            fetchMinutes();
-            fetchApproves();
+            setIsLoading(true);
+
+            Promise.all([fetchMinutes(), fetchApproves()]).finally(() =>
+                setIsLoading(false),
+            );
         }
     }, [projectInfo.projectId]);
 
@@ -81,7 +86,11 @@ export default function ProjectOverviewList() {
         <div className="flex flex-col gap-10">
             <p className="text-2xl font-bold">{projectInfo.projectTitle}</p>
 
-            {!minutesList.length ? (
+            {isLoading ? (
+                <div className="-translate-y-30">
+                    <LoadingIndicator type="minutes" />
+                </div>
+            ) : !minutesList.length ? (
                 <p className="text-gray-400">등록된 문서가 없습니다.</p>
             ) : (
                 groupedByMonth
@@ -104,11 +113,7 @@ export default function ProjectOverviewList() {
                                 return (
                                     <div
                                         key={info.minutesId}
-                                        className={`flex flex-col gap-3 ${
-                                            index !== minutesInfo.length - 1
-                                                ? "pb-4 border-b border-gray-200"
-                                                : ""
-                                        }`}
+                                        className="flex flex-col gap-3"
                                     >
                                         <OverviewCard
                                             minutesTitle={info.title}

--- a/wise-office-client/src/components/overview/ProjectOverviewList.tsx
+++ b/wise-office-client/src/components/overview/ProjectOverviewList.tsx
@@ -98,7 +98,7 @@ export default function ProjectOverviewList() {
                     .map(({ month, minutesInfo }) => (
                         <div key={month} className="flex flex-col gap-4 pr-16">
                             <p className="text-lg font-semibold">{month}월</p>
-                            {minutesInfo.map((info, index) => {
+                            {minutesInfo.map((info) => {
                                 const minutesDetail = minutesDetailList.find(
                                     (minutesDetail) =>
                                         minutesDetail.minutesId ===

--- a/wise-office-client/src/components/project/document/preview/PreviewContainer.tsx
+++ b/wise-office-client/src/components/project/document/preview/PreviewContainer.tsx
@@ -75,7 +75,7 @@ export default function PreviewContainer({
     const isError = queries.some((q) => q.isError);
 
     if (!selectedDoc) return <BasePreview type="log" />;
-    if (isLoading) return <LoadingIndicator type={"minute"} />;
+    if (isLoading) return <LoadingIndicator type="minutes" />;
     if (isError) return <div>에러 발생</div>;
 
     switch (docType) {

--- a/wise-office-client/src/components/ui/LoadingIndicator.tsx
+++ b/wise-office-client/src/components/ui/LoadingIndicator.tsx
@@ -1,4 +1,4 @@
-type dataType = "main" | "member" | "project" | "log" | "minute" | "approve";
+type dataType = "main" | "member" | "project" | "log" | "minutes" | "approval";
 
 interface LoadingIndicatorProps {
     type: dataType;
@@ -10,8 +10,8 @@ export default function LoadingIndicator({ type }: LoadingIndicatorProps) {
         member: ["사용자", "사용자 정보를"],
         project: ["프로젝트", "문서와 참여자 정보를"],
         log: ["로그", "로그와 댓글을"],
-        minute: ["회의록", "회의 내역과 관련 품의서를"],
-        approve: ["품의서", "품의 내역과 관련 회의록을"],
+        minutes: ["회의록", "회의 내역과 관련 품의서를"],
+        approval: ["품의서", "품의 내역과 관련 회의록을"],
     };
 
     return (

--- a/wise-office-client/src/pages/projects/[projectId]/documents/[docType]/[docId].tsx
+++ b/wise-office-client/src/pages/projects/[projectId]/documents/[docType]/[docId].tsx
@@ -218,7 +218,7 @@ export default function DocumentPage() {
     if (isLoading)
         return (
             <LoadingIndicator
-                type={docType === "minute" ? "minute" : "approve"}
+                type={docType === "minute" ? "minutes" : "approval"}
             />
         );
     if (!projectDetail.data) return <ErrorIndicator />;

--- a/wise-office-client/src/services/overview.ts
+++ b/wise-office-client/src/services/overview.ts
@@ -4,6 +4,7 @@ import {
     ApproveList,
     MinutesInfo,
     MinutesList,
+    MonthlyDocument,
 } from "@/types/document";
 
 export async function getMinutes(projectId: number): Promise<MinutesList> {
@@ -34,6 +35,17 @@ export async function getApproveInfo(
     const { data } = await api.get(
         `/projects/${projectId}/approves/${approveId}`,
     );
+
+    return data;
+}
+
+export async function getMonthlyDocuments(
+    year: number,
+    month: number,
+): Promise<MonthlyDocument[]> {
+    const { data } = await api.get(`/projects/documents`, {
+        params: { year, month },
+    });
 
     return data;
 }

--- a/wise-office-client/src/store/useOverviewStore.ts
+++ b/wise-office-client/src/store/useOverviewStore.ts
@@ -23,7 +23,7 @@ type OverviewState = {
 export const useOverviewStore = create<OverviewState>((set) => ({
     optionIndex: 0,
     year: new Date().getFullYear(),
-    month: new Date().getMonth(),
+    month: new Date().getMonth() + 1,
     projectInfo: { projectId: 0, projectTitle: "" },
 
     setOptionIndex: (optionIndex) => set({ optionIndex }),

--- a/wise-office-client/src/types/document.ts
+++ b/wise-office-client/src/types/document.ts
@@ -135,3 +135,27 @@ export interface PossibleAttendantsResponse {
     rank: string;
     canAttend: boolean;
 }
+
+export interface MinutesSummary {
+    minutesId: string;
+    minutesDate: string;
+    startTime: string;
+    endTime: string;
+    minutesTitle: string;
+    attendants: string;
+}
+
+export interface ApprovalSummary {
+    approveId: number;
+    approveTitle: string;
+}
+
+export interface DocumentPair {
+    minutes: MinutesSummary;
+    approve: ApprovalSummary | null;
+}
+
+export interface MonthlyDocument {
+    title: string;
+    pair: DocumentPair[];
+}

--- a/wise-office-client/src/types/document.ts
+++ b/wise-office-client/src/types/document.ts
@@ -156,6 +156,7 @@ export interface DocumentPair {
 }
 
 export interface MonthlyDocument {
+    projectId: number;
     title: string;
     pair: DocumentPair[];
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyDocumentGroupResponse.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyDocumentGroupResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record MonthlyDocumentGroupResponse(
+        @Schema(type = "number", description = "과제 ID") Long projectId,
         @Schema(type = "string", description = "과제 명 ") String title,
         @Schema(description = "회의록-품의서 쌍") List<MonthlyDocumentPairResponse> pair
 ) {

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyDocumentGroupResponse.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyDocumentGroupResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record MonthlyDocumentGroupResponse(
-        @Schema(type = "number", description = "과제 ID") Long projectId,
+        @Schema(description = "과제 ID") Long projectId,
         @Schema(type = "string", description = "과제 명 ") String title,
         @Schema(description = "회의록-품의서 쌍") List<MonthlyDocumentPairResponse> pair
 ) {

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyMinutesSummaryResponse.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/dto/overview/MonthlyMinutesSummaryResponse.java
@@ -13,7 +13,7 @@ public record MonthlyMinutesSummaryResponse(
         @Schema(type = "string", description = "회의 종료 시간") @JsonFormat(pattern = "HH:mm") LocalTime endTime,
         @Schema(type = "string", description = "회의록 번호") String minutesTitle,
         @Schema(type = "string", description = "참여자 리스트") String attendants,
-        @Schema(type = "string", description = "회의록 ID") Long minutesId
+        @Schema(description = "회의록 ID") Long minutesId
 ) {
 
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/OverviewServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/OverviewServiceApi.java
@@ -55,9 +55,9 @@ public class OverviewServiceApi {
         Map<Long, String> attendantsByMinutesId = getAttendantsByMinutesId(minutesIds);
         Map<Long, ApproveEntity> approveByMinutesId = getApproveByMinutesId(minutesIds);
 
-        // 과제명, 해당 과제에 기록된 회의록 및 품의서 목록 리스트
+        // 과제 id, 과제명, 해당 과제에 기록된 회의록 및 품의서 목록 리스트
         Map<Long, String> projectInfo = new HashMap<>();
-        Map<Long, List<MonthlyDocumentPairResponse>> result = new HashMap<>(); 
+        Map<Long, List<MonthlyDocumentPairResponse>> result = new HashMap<>();
         for (MinutesEntity minutes : targetMinutes) {
             Long projectId = minutes.getProject().getId();
             projectInfo.put(projectId, minutes.getProject().getTitle());

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/OverviewServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/OverviewServiceApi.java
@@ -56,20 +56,23 @@ public class OverviewServiceApi {
         Map<Long, ApproveEntity> approveByMinutesId = getApproveByMinutesId(minutesIds);
 
         // 과제명, 해당 과제에 기록된 회의록 및 품의서 목록 리스트
-        Map<String, List<MonthlyDocumentPairResponse>> result = new HashMap<>();
+        Map<Long, String> projectInfo = new HashMap<>();
+        Map<Long, List<MonthlyDocumentPairResponse>> result = new HashMap<>(); 
         for (MinutesEntity minutes : targetMinutes) {
+            Long projectId = minutes.getProject().getId();
+            projectInfo.put(projectId, minutes.getProject().getTitle());
             String attendantsName = attendantsByMinutesId.getOrDefault(minutes.getId(), "");
             MonthlyMinutesSummaryResponse minutesSummary = MonthlyMinutesSummaryResponse.from(minutes, attendantsName);
 
             ApproveEntity approve = approveByMinutesId.get(minutes.getId());
             MonthlyApproveSummaryResponse approveSummary = approve == null ? null : new MonthlyApproveSummaryResponse(approve.getReportNo(), approve.getId());
 
-            result.computeIfAbsent(minutes.getProject().getTitle(), ignored -> new ArrayList<>())
-                    .add(new MonthlyDocumentPairResponse(minutesSummary, approveSummary));
+            result.computeIfAbsent(projectId, ignored -> new ArrayList<>())
+                .add(new MonthlyDocumentPairResponse(minutesSummary, approveSummary));
         }
 
         return result.entrySet().stream()
-                .map(entry -> new MonthlyDocumentGroupResponse(entry.getKey(), entry.getValue()))
+                .map(entry -> new MonthlyDocumentGroupResponse(entry.getKey(), projectInfo.get(entry.getKey()), entry.getValue()))
                 .toList();
     }
 


### PR DESCRIPTION
# 📝 PR Summary
- 문서 현황 페이지에서 월별탭에서 표출되는 데이터를 연동함

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#313-month-overview

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 월별 데이터 연동
- [x] `LoadingIndicator` 컴포넌트 내 type minute -> minutes, approve -> approval (사용되는 부분도 수정함)
- [x] `api/projects/document` 에서 응답받는 데이터에 `projectId` 추가

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #313 

<!-- * @JakePark929 README작성. -->
