### PR TITLE
[FEATURE] 로그, 회의록 조회 시 시간복잡도 개선

### DIFF
--- a/wise-office-server/src/main/java/kr/co/wise/office/api/LogController.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/LogController.java
@@ -23,7 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @AllArgsConstructor

--- a/wise-office-server/src/main/java/kr/co/wise/office/api/dto/log/LogWithCountDto.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/api/dto/log/LogWithCountDto.java
@@ -1,0 +1,16 @@
+package kr.co.wise.office.api.dto.log;
+
+import kr.co.wise.office.domain.Log.entity.LogEntity;
+import lombok.Getter;
+
+@Getter
+public class LogWithCountDto {
+
+    private final LogEntity log;
+    private final Long commentCount;
+
+    public LogWithCountDto(LogEntity log, Long commentCount) {
+        this.log = log;
+        this.commentCount = commentCount;
+    }
+}

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -67,13 +69,22 @@ public class LogServiceApi {
                         (int) log.getComments().stream().filter(c -> !c.isDeleted()).count()))
                 .toList();
     }
-
     public Page<LogListResponse> searchLogPages(long projectId, String loginUserEmail, Pageable pageable) {
+
         MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
         ProjectEntity project = projectService.findById(projectId);
 
-        Page<LogWithCountDto> logPage =
-                logService.searchLogPages(project, pageable);
+        Page<LogEntity> logPage = logService.findLogs(project, pageable);
+
+        List<LogEntity> logs = logPage.getContent();
+
+        List<Object[]> commentCounts = logService.countComments(logs);
+
+        Map<Long, Long> countMap = commentCounts.stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],   // logId
+                        row -> (Long) row[1]    // count
+                ));
 
         Function<LogEntity, Boolean> modifyChecker;
         if (isAdmin(loginUser)) {
@@ -84,14 +95,15 @@ public class LogServiceApi {
             modifyChecker = log -> hasModifyPermission(loginUser, attendant, log);
         }
 
-        return logPage.map(dto ->
+        return logPage.map(log ->
                 LogListResponse.from(
-                        dto.getLog(),
-                        modifyChecker.apply(dto.getLog()),
-                        dto.getCommentCount().intValue()
+                        log,
+                        modifyChecker.apply(log),
+                        countMap.getOrDefault(log.getId(), 0L).intValue()
                 )
         );
     }
+
 
     public LogDetailResponse getDetailLog(long logId, long projectId, String loginUserEmail) {
         // 필요한 정보 조회

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -68,31 +68,6 @@ public class LogServiceApi {
                 .toList();
     }
 
-//    public Page<LogListResponse> searchLogPages(long projectId, String loginUserEmail, Pageable pageable) {
-//        MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
-//        ProjectEntity project = projectService.findById(projectId);
-//
-//        Page<LogEntity> logPage = logService.searchLogPages(project, pageable);
-//
-//        Function<LogEntity, Boolean> modifyChecker;
-//        if (isAdmin(loginUser)) {
-//            modifyChecker = log -> true;
-//        } else {
-//            AttendantEntity attendant =
-//                    attendantService.validateParticipatingProjectForViewing(loginUser, project);
-//            modifyChecker = log -> hasModifyPermission(loginUser, attendant, log);
-//        }
-//
-//        return logPage.map(log ->
-//                LogListResponse.from(
-//                        log,
-//                        modifyChecker.apply(log),
-//                        (int) log.getComments().stream()
-//                                .filter(c -> !c.isDeleted())
-//                                .count()
-//                )
-//        );
-//    }
     public Page<LogListResponse> searchLogPages(long projectId, String loginUserEmail, Pageable pageable) {
         MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
         ProjectEntity project = projectService.findById(projectId);

--- a/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/application/LogServiceApi.java
@@ -1,5 +1,6 @@
 package kr.co.wise.office.application;
 
+import kr.co.wise.office.api.dto.log.LogWithCountDto;
 import kr.co.wise.office.domain.Log.dto.*;
 import kr.co.wise.office.domain.Log.entity.LogEntity;
 import kr.co.wise.office.domain.Log.service.LogService;
@@ -67,11 +68,37 @@ public class LogServiceApi {
                 .toList();
     }
 
+//    public Page<LogListResponse> searchLogPages(long projectId, String loginUserEmail, Pageable pageable) {
+//        MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
+//        ProjectEntity project = projectService.findById(projectId);
+//
+//        Page<LogEntity> logPage = logService.searchLogPages(project, pageable);
+//
+//        Function<LogEntity, Boolean> modifyChecker;
+//        if (isAdmin(loginUser)) {
+//            modifyChecker = log -> true;
+//        } else {
+//            AttendantEntity attendant =
+//                    attendantService.validateParticipatingProjectForViewing(loginUser, project);
+//            modifyChecker = log -> hasModifyPermission(loginUser, attendant, log);
+//        }
+//
+//        return logPage.map(log ->
+//                LogListResponse.from(
+//                        log,
+//                        modifyChecker.apply(log),
+//                        (int) log.getComments().stream()
+//                                .filter(c -> !c.isDeleted())
+//                                .count()
+//                )
+//        );
+//    }
     public Page<LogListResponse> searchLogPages(long projectId, String loginUserEmail, Pageable pageable) {
         MemberEntity loginUser = memberService.findByEmail(loginUserEmail);
         ProjectEntity project = projectService.findById(projectId);
 
-        Page<LogEntity> logPage = logService.searchLogPages(project, pageable);
+        Page<LogWithCountDto> logPage =
+                logService.searchLogPages(project, pageable);
 
         Function<LogEntity, Boolean> modifyChecker;
         if (isAdmin(loginUser)) {
@@ -82,13 +109,11 @@ public class LogServiceApi {
             modifyChecker = log -> hasModifyPermission(loginUser, attendant, log);
         }
 
-        return logPage.map(log ->
+        return logPage.map(dto ->
                 LogListResponse.from(
-                        log,
-                        modifyChecker.apply(log),
-                        (int) log.getComments().stream()
-                                .filter(c -> !c.isDeleted())
-                                .count()
+                        dto.getLog(),
+                        modifyChecker.apply(dto.getLog()),
+                        dto.getCommentCount().intValue()
                 )
         );
     }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/entity/LogEntity.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/entity/LogEntity.java
@@ -52,7 +52,6 @@ public class LogEntity {
     private ProjectEntity project;
 
     @OneToMany(mappedBy = "log")
-    @BatchSize(size = 100)
     @Builder.Default
     private List<CommentEntity> comments = new ArrayList<>();
 

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
@@ -5,6 +5,7 @@ import kr.co.wise.office.domain.Log.entity.LogEntity;
 import kr.co.wise.office.domain.Project.entity.ProjectEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -27,27 +28,21 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
     @Query("update LogEntity l set l.deleted = true where l.id = :logId")
     void deleteLog(@Param("logId") long logId);
 
-    @Query(
-            value = """
-        select new kr.co.wise.office.api.dto.log.LogWithCountDto(
-            l,
-            count(c)
-        )
-        from LogEntity l
-        left join l.comments c on c.deleted = false
-        where l.deleted = false
-          and l.project = :project
-        group by l
-    """,
-            countQuery = """
-        select count(l)
+    @EntityGraph(attributePaths = "member")
+    @Query("""
+        select l
         from LogEntity l
         where l.deleted = false
           and l.project = :project
-    """
-    )
-    Page<LogWithCountDto> findLogsWithCommentCount(
-            @Param("project") ProjectEntity project,
-            Pageable pageable
-    );
+    """)
+    Page<LogEntity> findLogs(ProjectEntity project, Pageable pageable);
+
+    @Query("""
+        select c.log.id, count(c)
+        from CommentEntity c
+        where c.deleted = false
+          and c.log in :logs
+        group by c.log.id
+    """)
+    List<Object[]> countComments(List<LogEntity> logs);
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
@@ -1,5 +1,6 @@
 package kr.co.wise.office.domain.Log.repository;
 
+import kr.co.wise.office.api.dto.log.LogWithCountDto;
 import kr.co.wise.office.domain.Log.entity.LogEntity;
 import kr.co.wise.office.domain.Project.entity.ProjectEntity;
 import org.springframework.data.domain.Page;
@@ -33,4 +34,27 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
     @Query("update LogEntity l set l.deleted = true where l.id = :logId")
     void deleteLog(@Param("logId") long logId);
 
+    @Query(
+            value = """
+        select new kr.co.wise.office.api.dto.log.LogWithCountDto(
+            l,
+            count(c)
+        )
+        from LogEntity l
+        left join l.comments c on c.deleted = false
+        where l.deleted = false
+          and l.project = :project
+        group by l
+    """,
+            countQuery = """
+        select count(l)
+        from LogEntity l
+        where l.deleted = false
+          and l.project = :project
+    """
+    )
+    Page<LogWithCountDto> findLogsWithCommentCount(
+            @Param("project") ProjectEntity project,
+            Pageable pageable
+    );
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/repository/LogRepository.java
@@ -19,13 +19,6 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
 
     @Query("select l from LogEntity l join fetch l.member left join fetch l.comments where l.deleted = false and l.project = :project order by l.id desc")
     Optional<List<LogEntity>> findByLogWithComments(@Param("project") ProjectEntity project);
-        
-//        페이징용
-    @Query(
-            value = "select l from LogEntity l join fetch l.member where l.deleted = false and l.project = :project",
-            countQuery = "select count(l) from LogEntity l where l.deleted = false and l.project = :project"
-    )
-    Page<LogEntity> findByLogWithComments(@Param("project") ProjectEntity project, Pageable pageable);
 
     @Query("select l from LogEntity l join fetch l.member where l.deleted = false and l.id = :logId")
     Optional<LogEntity> findByIdWithMember(@Param("logId") long logId);

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
@@ -34,9 +34,13 @@ public class LogService {
         return logRepository.findByLogWithComments(project).orElse(Collections.emptyList());
     }
 
-public Page<LogWithCountDto> searchLogPages(ProjectEntity project, Pageable pageable) {
-    return logRepository.findLogsWithCommentCount(project, pageable);
-}
+    public Page<LogEntity> findLogs(ProjectEntity project, Pageable pageable) {
+        return logRepository.findLogs(project, pageable);
+    }
+
+    public List<Object[]> countComments(List<LogEntity> logs) {
+        return logRepository.countComments(logs);
+    }
 
     public LogEntity searchLog(long logId) {
         return logRepository.findByIdWithMember(logId).orElseThrow(() -> new NotFoundResourceException(ErrorMessage.NOT_FOUND_LOG));

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
@@ -1,5 +1,6 @@
 package kr.co.wise.office.domain.Log.service;
 
+import kr.co.wise.office.api.dto.log.LogWithCountDto;
 import kr.co.wise.office.domain.Log.dto.LogCreateRequest;
 import kr.co.wise.office.domain.Log.dto.LogUpdateRequest;
 import kr.co.wise.office.domain.Log.entity.LogEntity;
@@ -33,9 +34,12 @@ public class LogService {
         return logRepository.findByLogWithComments(project).orElse(Collections.emptyList());
     }
 
-    public Page<LogEntity> searchLogPages(ProjectEntity project, Pageable pageable) {
-        return logRepository.findByLogWithComments(project, pageable);
-    }
+//    public Page<LogEntity> searchLogPages(ProjectEntity project, Pageable pageable) {
+//        return logRepository.findByLogWithComments(project, pageable);
+//    }
+public Page<LogWithCountDto> searchLogPages(ProjectEntity project, Pageable pageable) {
+    return logRepository.findLogsWithCommentCount(project, pageable);
+}
 
     public LogEntity searchLog(long logId) {
         return logRepository.findByIdWithMember(logId).orElseThrow(() -> new NotFoundResourceException(ErrorMessage.NOT_FOUND_LOG));

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/Log/service/LogService.java
@@ -34,9 +34,6 @@ public class LogService {
         return logRepository.findByLogWithComments(project).orElse(Collections.emptyList());
     }
 
-//    public Page<LogEntity> searchLogPages(ProjectEntity project, Pageable pageable) {
-//        return logRepository.findByLogWithComments(project, pageable);
-//    }
 public Page<LogWithCountDto> searchLogPages(ProjectEntity project, Pageable pageable) {
     return logRepository.findLogsWithCommentCount(project, pageable);
 }

--- a/wise-office-server/src/main/java/kr/co/wise/office/domain/minutes/service/MinutesService.java
+++ b/wise-office-server/src/main/java/kr/co/wise/office/domain/minutes/service/MinutesService.java
@@ -48,12 +48,15 @@ public class MinutesService {
         List<ProposalAttendantEntity> writerInfos = proposalAttendantsService.findWriterInfos(proposalAttendantId, projectId);
 
         List<MinutesListResponse> result = new ArrayList<>();
+        Map<Long, ProposalAttendantEntity> writerMap = writerInfos.stream()
+                .collect(Collectors.toMap(ProposalAttendantEntity::getId, w -> w));
+
         for (MinutesEntity minutesEntity : minutesEntities) {
             Long writerId = Long.parseLong(minutesEntity.getWriter());
-            for (ProposalAttendantEntity writerInfo : writerInfos) {
-                if (writerId.equals(writerInfo.getId())) {
-                    result.add(MinutesListResponse.from(minutesEntity, writerInfo.getCompanyMember()));
-                }
+            ProposalAttendantEntity writerInfo = writerMap.get(writerId);
+
+            if (writerInfo != null) {
+                result.add(MinutesListResponse.from(minutesEntity, writerInfo.getCompanyMember()));
             }
         }
 


### PR DESCRIPTION
# 📝 PR Summary
- 로그(댓글), 회의록 조회 시 발생하는 N+1 쿼리 문데, O(NxM) 해결

### 🌲 Working Branch
<!-- 작업한 브랜치 이름 작성 -->
feat/#325-query-optimization

### 🌲 TODOs
<!-- 진행한 TODO List 작성 -->
- [x] 로그 및 댓글 조회 시의 시간복잡도 개선
- [x] 회의록 조회 시 시간복잡도 개선

### 📚 Remarks
<!-- 기능 개발에 있어 비고사항이 있었다면 적기 -->
-

### Related Issues
<!-- 이슈 번호 작성 -->
resolve #325 

<!-- * @JakePark929 README작성. -->
